### PR TITLE
feat: Add parameter description to properties

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -220,6 +220,7 @@ class Endpoint:
                 data=param.param_schema,
                 schemas=schemas,
                 parent_name=endpoint.name,
+                description=param.description,
             )
             if isinstance(prop, ParseError):
                 return ParseError(detail=f"cannot parse parameter of endpoint {endpoint.name}", data=prop.data), schemas

--- a/openapi_python_client/parser/properties/property.py
+++ b/openapi_python_client/parser/properties/property.py
@@ -25,6 +25,7 @@ class Property:
     nullable: bool
     _type_string: ClassVar[str] = ""
     default: Optional[str] = attr.ib()
+    description: Optional[str]
     python_name: str = attr.ib(init=False)
 
     template: ClassVar[Optional[str]] = None


### PR DESCRIPTION
This is draft to propose adding the parameter description from the OpenAPI schema to the properties based on the comment here: https://github.com/triaxtec/openapi-python-client/issues/224#issuecomment-782482118.  This proves useful if it's coupled with a mkdocs template using mkdocstrings so that the parameter descriptions in the OpenAPI spec can be included in the docs.

Still requires tests and formatting/cleanup but feedback on if there is interest in this and it's taking the right approach would be appreciated.

This PR could be expanded to include the template and method to handle mkdocs.