### PR TITLE
fix: Treat `None` as `UNSET` in query params for model properties, etc.

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -38,11 +38,14 @@ def _get_kwargs(
     cookies: Dict[str, Any] = client.get_cookies()
 
     json_not_required_not_nullable_datetime_prop: Union[Unset, str] = UNSET
-    if not isinstance(not_required_not_nullable_datetime_prop, Unset):
+    if (
+        not isinstance(not_required_not_nullable_datetime_prop, Unset)
+        and not_required_not_nullable_datetime_prop is not None
+    ):
         json_not_required_not_nullable_datetime_prop = not_required_not_nullable_datetime_prop.isoformat()
 
     json_not_required_nullable_datetime_prop: Union[Unset, None, str] = UNSET
-    if not isinstance(not_required_nullable_datetime_prop, Unset):
+    if not isinstance(not_required_nullable_datetime_prop, Unset) and not_required_nullable_datetime_prop is not None:
         json_not_required_nullable_datetime_prop = (
             not_required_nullable_datetime_prop.isoformat() if not_required_nullable_datetime_prop else None
         )
@@ -54,11 +57,11 @@ def _get_kwargs(
     )
 
     json_date_prop: Union[Unset, str] = UNSET
-    if not isinstance(date_prop, Unset):
+    if not isinstance(date_prop, Unset) and date_prop is not None:
         json_date_prop = date_prop.isoformat()
 
     json_list_prop: Union[Unset, List[str]] = UNSET
-    if not isinstance(list_prop, Unset):
+    if not isinstance(list_prop, Unset) and list_prop is not None:
         json_list_prop = []
         for list_prop_item_data in list_prop:
             list_prop_item = list_prop_item_data.value
@@ -66,13 +69,13 @@ def _get_kwargs(
             json_list_prop.append(list_prop_item)
 
     json_union_prop: Union[Unset, float, str]
-    if isinstance(union_prop, Unset):
+    if isinstance(union_prop, Unset) or union_prop is None:
         json_union_prop = UNSET
     else:
         json_union_prop = union_prop
 
     json_union_prop_with_ref: Union[Unset, float, str]
-    if isinstance(union_prop_with_ref, Unset):
+    if isinstance(union_prop_with_ref, Unset) or union_prop_with_ref is None:
         json_union_prop_with_ref = UNSET
     elif isinstance(union_prop_with_ref, AnEnum):
         json_union_prop_with_ref = UNSET
@@ -83,17 +86,17 @@ def _get_kwargs(
         json_union_prop_with_ref = union_prop_with_ref
 
     json_enum_prop: Union[Unset, str] = UNSET
-    if not isinstance(enum_prop, Unset):
+    if not isinstance(enum_prop, Unset) and enum_prop is not None:
         json_enum_prop = enum_prop.value
 
     json_model_prop: Union[Unset, Dict[str, Any]] = UNSET
-    if not isinstance(model_prop, Unset):
+    if not isinstance(model_prop, Unset) and model_prop is not None:
         json_model_prop = model_prop.to_dict()
 
     json_required_model_prop = required_model_prop.to_dict()
 
     json_nullable_model_prop: Union[Unset, None, Dict[str, Any]] = UNSET
-    if not isinstance(nullable_model_prop, Unset):
+    if not isinstance(nullable_model_prop, Unset) and nullable_model_prop is not None:
         json_nullable_model_prop = nullable_model_prop.to_dict() if nullable_model_prop else None
 
     json_nullable_required_model_prop = nullable_required_model_prop.to_dict() if nullable_required_model_prop else None

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/optional_value_tests_optional_query_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/optional_value_tests_optional_query_param.py
@@ -18,7 +18,7 @@ def _get_kwargs(
     cookies: Dict[str, Any] = client.get_cookies()
 
     json_query_param: Union[Unset, List[str]] = UNSET
-    if not isinstance(query_param, Unset):
+    if not isinstance(query_param, Unset) and query_param is not None:
         json_query_param = query_param
 
     params: Dict[str, Any] = {

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -31,7 +31,7 @@ if {{ parameter.python_name }} is not UNSET:
         {% set destination = "json_" + property.python_name %}
         {% if property.template %}
             {% from "property_templates/" + property.template import transform %}
-{{ transform(property, property.python_name, destination) }}
+{{ transform(property, property.python_name, destination, query_param=True) }}
         {% endif %}
     {% endfor %}
 params: Dict[str, Any] = {

--- a/openapi_python_client/templates/property_templates/date_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/date_property.py.jinja
@@ -10,12 +10,12 @@ isoparse({{ source }}).date()
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, str){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if property.required %}
 {{ destination }} = {{ source }}.isoformat() {% if property.nullable %}if {{ source }} else None {%endif%}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     {{ destination }} = {{ source }}.isoformat() if {{ source }} else None
 {% else %}

--- a/openapi_python_client/templates/property_templates/datetime_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/datetime_property.py.jinja
@@ -10,7 +10,7 @@ isoparse({{ source }})
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, str){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if property.required %}
 {% if property.nullable %}
 {{ destination }} = {{ source }}.isoformat() if {{ source }} else None
@@ -19,7 +19,7 @@ isoparse({{ source }})
 {% endif %}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     {{ destination }} = {{ source }}.isoformat() if {{ source }} else None
 {% else %}

--- a/openapi_python_client/templates/property_templates/enum_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/enum_property.py.jinja
@@ -10,7 +10,7 @@
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, {{ property.value_type.__name__ }}){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if property.required %}
 {% if property.nullable %}
 {{ destination }} = {{ source }}.value if {{ source }} else None
@@ -19,7 +19,7 @@
 {% endif %}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     {{ destination }} = {{ source }}.value if {{ source }} else None
 {% else %}

--- a/openapi_python_client/templates/property_templates/file_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/file_property.py.jinja
@@ -12,7 +12,7 @@ File(
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, bytes){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if property.required %}
 {% if property.nullable %}
 {{ destination }} = {{ source }}.to_tuple() if {{ source }} else None
@@ -21,7 +21,7 @@ File(
 {% endif %}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     {{ destination }} = {{ source }}.to_tuple() if {{ source }} else None
 {% else %}

--- a/openapi_python_client/templates/property_templates/list_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/list_property.py.jinja
@@ -33,7 +33,7 @@ for {{ inner_source }} in {{ source }}:
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, list){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% set inner_property = property.inner_property %}
 {% if property.required %}
 {% if property.nullable %}
@@ -46,7 +46,7 @@ else:
 {% endif %}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     if {{ source }} is None:
         {{ destination }} = None

--- a/openapi_python_client/templates/property_templates/model_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/model_property.py.jinja
@@ -10,7 +10,7 @@
 
 {% macro check_type_for_construct(property, source) %}isinstance({{ source }}, dict){% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if property.required %}
 {% if property.nullable %}
 {{ destination }} = {{ source }}.to_dict() if {{ source }} else None
@@ -19,7 +19,7 @@
 {% endif %}
 {% else %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %} = UNSET
-if not isinstance({{ source }}, Unset):
+if not isinstance({{ source }}, Unset){% if query_param %} and {{ source }} is not None{% endif %}:
 {% if property.nullable %}
     {{ destination }} = {{ source }}.to_dict() if {{ source }} else None
 {% else %}

--- a/openapi_python_client/templates/property_templates/none_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/none_property.py.jinja
@@ -4,6 +4,6 @@
 
 {% macro check_type_for_construct(property, source) %}{{ source }} is None{% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {{ destination }} =  None
 {% endmacro %}

--- a/openapi_python_client/templates/property_templates/union_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/union_property.py.jinja
@@ -39,12 +39,12 @@ def _parse_{{ property.python_name }}(data: object) -> {{ property.get_type_stri
 {# For now we assume there will be no unions of unions #}
 {% macro check_type_for_construct(property, source) %}True{% endmacro %}
 
-{% macro transform(property, source, destination, declare_type=True) %}
+{% macro transform(property, source, destination, declare_type=True, query_param=False) %}
 {% if not property.required or property.nullable %}
 {{ destination }}{% if declare_type %}: {{ property.get_type_string(json=True) }}{% endif %}
 
 {% if not property.required %}
-if isinstance({{ source }}, Unset):
+if isinstance({{ source }}, Unset){% if query_param %} or {{ source }} is None{% endif %}:
     {{ destination }} = UNSET
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Fixes some missing cases not covered by the original implementation in https://github.com/triaxtec/openapi-python-client/pull/331. In particular, properties with non-trivial serialization would crash when `None` was passed instead of `UNSET`.

Closes https://github.com/triaxtec/openapi-python-client/issues/380.