### PR TITLE
Path parameters as function positional arguments

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -1,33 +1,27 @@
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response, Unset
+from ...types import Response
 
 
 def _get_kwargs(
-    param_path: str,
+    param_1: str,
+    param_2: int,
     *,
     client: Client,
-    param_query: Union[Unset, str] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/same-name-multiple-locations/{param}".format(client.base_url, param=param_path)
+    url = "{}/multiple-path-parameters/{param1}/{param2}".format(client.base_url, param1=param_1, param2=param_2)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
-
-    params: Dict[str, Any] = {
-        "param": param_query,
-    }
-    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     return {
         "url": url,
         "headers": headers,
         "cookies": cookies,
         "timeout": client.get_timeout(),
-        "params": params,
     }
 
 
@@ -41,15 +35,15 @@ def _build_response(*, response: httpx.Response) -> Response[None]:
 
 
 def sync_detailed(
-    param_path: str,
+    param_1: str,
+    param_2: int,
     *,
     client: Client,
-    param_query: Union[Unset, str] = UNSET,
 ) -> Response[None]:
     kwargs = _get_kwargs(
-        param_path=param_path,
+        param_1=param_1,
+        param_2=param_2,
         client=client,
-        param_query=param_query,
     )
 
     response = httpx.get(
@@ -60,15 +54,15 @@ def sync_detailed(
 
 
 async def asyncio_detailed(
-    param_path: str,
+    param_1: str,
+    param_2: int,
     *,
     client: Client,
-    param_query: Union[Unset, str] = UNSET,
 ) -> Response[None]:
     kwargs = _get_kwargs(
-        param_path=param_path,
+        param_1=param_1,
+        param_2=param_2,
         client=client,
-        param_query=param_query,
     )
 
     async with httpx.AsyncClient() as _client:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -7,12 +7,16 @@ from ...types import Response
 
 
 def _get_kwargs(
-    param_1: str,
+    param_4: str,
     param_2: int,
+    param_1: str,
+    param_3: int,
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/multiple-path-parameters/{param1}/{param2}".format(client.base_url, param1=param_1, param2=param_2)
+    url = "{}/multiple-path-parameters/{param4}/{param2}/{param1}/{param3}".format(
+        client.base_url, param4=param_4, param2=param_2, param1=param_1, param3=param_3
+    )
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
@@ -35,14 +39,18 @@ def _build_response(*, response: httpx.Response) -> Response[None]:
 
 
 def sync_detailed(
-    param_1: str,
+    param_4: str,
     param_2: int,
+    param_1: str,
+    param_3: int,
     *,
     client: Client,
 ) -> Response[None]:
     kwargs = _get_kwargs(
-        param_1=param_1,
+        param_4=param_4,
         param_2=param_2,
+        param_1=param_1,
+        param_3=param_3,
         client=client,
     )
 
@@ -54,14 +62,18 @@ def sync_detailed(
 
 
 async def asyncio_detailed(
-    param_1: str,
+    param_4: str,
     param_2: int,
+    param_1: str,
+    param_3: int,
     *,
     client: Client,
 ) -> Response[None]:
     kwargs = _get_kwargs(
-        param_1=param_1,
+        param_4=param_4,
         param_2=param_2,
+        param_1=param_1,
+        param_3=param_3,
         client=client,
     )
 

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -795,8 +795,8 @@
         }
       }
     },
-    "/multiple-path-parameters/{param1}/{param2}": {
-      "description": "Test with multiple path parameters",
+    "/multiple-path-parameters/{param4}/{param2}/{param1}/{param3}": {
+      "description": "Test that multiple path parameters are ordered by appearance in path",
       "get": {
         "tags": [
           "parameters"
@@ -825,7 +825,25 @@
             "description": "Success"
           }
         }
-      }
+      },
+      "parameters": [
+        {
+          "name": "param4",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "param3",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
     }
   },
   "components": {

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -782,6 +782,7 @@
           {
             "name": "param",
             "in": "path",
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -790,6 +791,38 @@
         "responses": {
           "200": {
             "description": ""
+          }
+        }
+      }
+    },
+    "/multiple-path-parameters/{param1}/{param2}": {
+      "description": "Test with multiple path parameters",
+      "get": {
+        "tags": [
+          "parameters"
+        ],
+        "operationId": "multiple_path_parameters",
+        "parameters": [
+          {
+            "name": "param1",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "param2",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
           }
         }
       }

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -245,6 +245,8 @@ class Endpoint:
             if param.param_in == oai.ParameterLocation.QUERY:
                 endpoint.query_parameters.append(prop)
             elif param.param_in == oai.ParameterLocation.PATH:
+                if not param.required:
+                    return ParseError(data=param, detail="Path parameter must be required"), schemas
                 endpoint.path_parameters.append(prop)
             elif param.param_in == oai.ParameterLocation.HEADER:
                 endpoint.header_parameters.append(prop)

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -284,7 +284,7 @@ class Endpoint:
         path_parameter_names = [p.name for p in endpoint.path_parameters]
         if parameters_from_path != path_parameter_names:
             return ParseError(
-                data=endpoint.path_parameters,
+                data=endpoint,
                 detail="Incorrect path templating (Path parameters do not match with path)",
             )
         return endpoint

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -276,15 +276,17 @@ class Endpoint:
     @staticmethod
     def _sort_parameters(*, endpoint: "Endpoint", path: str) -> Union["Endpoint", ParseError]:
         endpoint = deepcopy(endpoint)
-        parameters_form_path = re.findall(_PATH_PARAM_REGEX, path)
+        parameters_from_path = re.findall(_PATH_PARAM_REGEX, path)
+        try:
+            endpoint.path_parameters.sort(key=lambda p: parameters_from_path.index(p.name))
+        except ValueError:
+            pass  # We're going to catch the difference down below
         path_parameter_names = [p.name for p in endpoint.path_parameters]
-        if sorted(parameters_form_path) != sorted(path_parameter_names):
+        if parameters_from_path != path_parameter_names:
             return ParseError(
                 data=endpoint.path_parameters,
                 detail="Incorrect path templating (Path parameters do not match with path)",
             )
-
-        endpoint.path_parameters.sort(key=lambda p: parameters_form_path.index(p.name))
         return endpoint
 
     @staticmethod

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
@@ -11,6 +12,8 @@ from ..config import Config
 from .errors import GeneratorError, ParseError, PropertyError
 from .properties import Class, EnumProperty, ModelProperty, Property, Schemas, build_schemas, property_from_data
 from .responses import Response, response_from_data
+
+_PATH_PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)}")
 
 
 def import_string_from_class(class_: Class, prefix: str = "") -> str:
@@ -49,6 +52,8 @@ class EndpointCollection:
                     endpoint, schemas = Endpoint._add_parameters(
                         endpoint=endpoint, data=path_data, schemas=schemas, config=config
                     )
+                if not isinstance(endpoint, ParseError):
+                    endpoint = Endpoint._sort_parameters(endpoint=endpoint, path=path)
                 if isinstance(endpoint, ParseError):
                     endpoint.header = (
                         f"ERROR parsing {method.upper()} {path} within {tag}. Endpoint will not be generated."
@@ -267,6 +272,20 @@ class Endpoint:
             name_check.add(prop.python_name)
 
         return endpoint, schemas
+
+    @staticmethod
+    def _sort_parameters(*, endpoint: "Endpoint", path: str) -> Union["Endpoint", ParseError]:
+        endpoint = deepcopy(endpoint)
+        parameters_form_path = re.findall(_PATH_PARAM_REGEX, path)
+        path_parameter_names = [p.name for p in endpoint.path_parameters]
+        if sorted(parameters_form_path) != sorted(path_parameter_names):
+            return ParseError(
+                data=endpoint.path_parameters,
+                detail="Incorrect path templating (Path parameters do not match with path)",
+            )
+
+        endpoint.path_parameters.sort(key=lambda p: parameters_form_path.index(p.name))
+        return endpoint
 
     @staticmethod
     def from_data(

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -73,6 +73,10 @@ params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
 {# The all the kwargs passed into an endpoint (and variants thereof)) #}
 {% macro arguments(endpoint) %}
+{# path parameters #}
+{% for parameter in endpoint.path_parameters %}
+{{ parameter.to_string() }},
+{% endfor %}
 *,
 {# Proper client based on whether or not the endpoint requires authentication #}
 {% if endpoint.requires_security %}
@@ -80,10 +84,6 @@ client: AuthenticatedClient,
 {% else %}
 client: Client,
 {% endif %}
-{# path parameters #}
-{% for parameter in endpoint.path_parameters %}
-{{ parameter.to_string() }},
-{% endfor %}
 {# Form data if any #}
 {% if endpoint.form_body_class %}
 form_data: {{ endpoint.form_body_class.name }},
@@ -111,10 +111,10 @@ json_body: {{ endpoint.json_body.get_type_string() }},
 
 {# Just lists all kwargs to endpoints as name=name for passing to other functions #}
 {% macro kwargs(endpoint) %}
-client=client,
 {% for parameter in endpoint.path_parameters %}
 {{ parameter.python_name }}={{ parameter.python_name }},
 {% endfor %}
+client=client,
 {% if endpoint.form_body_class %}
 form_data=form_data,
 {% endif %}

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -637,7 +637,7 @@ class TestEndpoint:
         result = Endpoint._sort_parameters(endpoint=endpoint, path=path)
 
         assert isinstance(result, ParseError)
-        assert result.data == [param]
+        assert result.data == endpoint
         assert "Incorrect path templating" in result.detail
 
     def test_from_data_bad_params(self, mocker):

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -447,6 +447,23 @@ class TestEndpoint:
             property_schemas,
         )
 
+    def test__add_parameters_parse_error_on_non_required_path_param(self, mocker):
+        from openapi_python_client.parser.openapi import Endpoint, Schemas
+
+        endpoint = self.make_endpoint()
+        parsed_schemas = mocker.MagicMock()
+        mocker.patch(f"{MODULE_NAME}.property_from_data", return_value=(mocker.MagicMock(), parsed_schemas))
+        param = oai.Parameter.construct(
+            name="test", required=False, param_schema=mocker.MagicMock(), param_in=oai.ParameterLocation.PATH
+        )
+        schemas = Schemas()
+        config = MagicMock()
+
+        result = Endpoint._add_parameters(
+            endpoint=endpoint, data=oai.Operation.construct(parameters=[param]), schemas=schemas, config=config
+        )
+        assert result == (ParseError(data=param, detail="Path parameter must be required"), parsed_schemas)
+
     def test__add_parameters_fail_loudly_when_location_not_supported(self, mocker):
         from openapi_python_client.parser.openapi import Endpoint, Schemas
 

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -606,6 +606,40 @@ class TestEndpoint:
         assert result.query_parameters[0].python_name == "test_query"
         assert result.query_parameters[0].name == "test"
 
+    def test__sort_parameters(self, mocker):
+        from openapi_python_client.parser.openapi import Endpoint
+
+        endpoint = self.make_endpoint()
+        path = "/multiple-path-parameters/{param4}/{param2}/{param1}/{param3}"
+
+        for i in range(1, 5):
+            param = oai.Parameter.construct(
+                name=f"param{i}", required=True, param_schema=mocker.MagicMock(), param_in=oai.ParameterLocation.PATH
+            )
+            endpoint.path_parameters.append(param)
+
+        result = Endpoint._sort_parameters(endpoint=endpoint, path=path)
+        result_names = [p.name for p in result.path_parameters]
+        expected_names = [f"param{i}" for i in (4, 2, 1, 3)]
+
+        assert result_names == expected_names
+
+    def test__sort_parameters_invalid_path_templating(self, mocker):
+        from openapi_python_client.parser.openapi import Endpoint
+
+        endpoint = self.make_endpoint()
+        path = "/multiple-path-parameters/{param1}/{param2}"
+        param = oai.Parameter.construct(
+            name=f"param1", required=True, param_schema=mocker.MagicMock(), param_in=oai.ParameterLocation.PATH
+        )
+        endpoint.path_parameters.append(param)
+
+        result = Endpoint._sort_parameters(endpoint=endpoint, path=path)
+
+        assert isinstance(result, ParseError)
+        assert result.data == [param]
+        assert "Incorrect path templating" in result.detail
+
     def test_from_data_bad_params(self, mocker):
         from openapi_python_client.parser.openapi import Endpoint
 

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -630,7 +630,7 @@ class TestEndpoint:
         endpoint = self.make_endpoint()
         path = "/multiple-path-parameters/{param1}/{param2}"
         param = oai.Parameter.construct(
-            name=f"param1", required=True, param_schema=mocker.MagicMock(), param_in=oai.ParameterLocation.PATH
+            name="param1", required=True, param_schema=mocker.MagicMock(), param_in=oai.ParameterLocation.PATH
         )
         endpoint.path_parameters.append(param)
 


### PR DESCRIPTION
OpenAPI Specification indicates that if parameter location is `path` the `required` property is REQUIRED and its value MUST be `true`

Ref: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#parameter-object

With this in mind, this PR:

- Tighten the parsing by throwing an error for path parameters with required=false
- Update the templates to pass the path parameters to the function as positional arguments instead of kwargs
to improve usability