### PR TITLE
feat: support references to unprocessed schemas

### DIFF
--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -171,6 +171,9 @@ def _process_properties(
             optional_properties.append(prop)
         relative_imports.update(prop.get_imports(prefix=".."))
 
+    # Except circular import
+    relative_imports = {relative_import for relative_import in relative_imports if "import " + class_name + "\n" not in relative_import}
+
     return _PropertyData(
         optional_props=optional_properties,
         required_props=required_properties,

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -255,9 +255,6 @@ def build_model_property(
         additional_properties=additional_properties,
         python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
     )
-    if class_info.name in schemas.classes_by_name:
-        error = PropertyError(data=data, detail=f'Attempted to generate duplicate models with name "{class_info.name}"')
-        return error, schemas
 
     schemas = attr.evolve(schemas, classes_by_name={**schemas.classes_by_name, class_info.name: prop})
     return prop, schemas

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -172,7 +172,7 @@ def _process_properties(
         relative_imports.update(prop.get_imports(prefix=".."))
 
     # Except circular import
-    relative_imports = {relative_import for relative_import in relative_imports if "import " + class_name + "\n" not in relative_import}
+    relative_imports = {relative_import for relative_import in relative_imports if not relative_import.endswith("import " + class_name)}
 
     return _PropertyData(
         optional_props=optional_properties,

--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -31,12 +31,12 @@ class {{ class_name }}:
     """ {{ model.description }} """
     {% for property in model.required_properties + model.optional_properties %}
     {% if property.default is none and property.required %}
-    {{ property.to_string() }}
+    {{ property.to_string().replace(" " + class_name + "]", " T]") }}
     {% endif %}
     {% endfor %}
     {% for property in model.required_properties + model.optional_properties %}
     {% if property.default is not none or not property.required %}
-    {{ property.to_string() }}
+    {{ property.to_string().replace(" " + class_name + "]", " T]") }}
     {% endif %}
     {% endfor %}
     {% if model.additional_properties %}

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -127,19 +127,6 @@ class TestBuildModelProperty:
             additional_properties=True,
         )
 
-    def test_model_name_conflict(self):
-        from openapi_python_client.parser.properties import Schemas, build_model_property
-
-        data = oai.Schema.construct()
-        schemas = Schemas(classes_by_name={"OtherModel": None})
-
-        err, new_schemas = build_model_property(
-            data=data, name="OtherModel", schemas=schemas, required=True, parent_name=None, config=Config()
-        )
-
-        assert new_schemas == schemas
-        assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
-
     def test_bad_props_return_error(self):
         from openapi_python_client.parser.properties import Schemas, build_model_property
 


### PR DESCRIPTION
This PR aims to support references to schemas that have not been processed yet. Please see #466.

Strategy is to create models for indirect references without properties. And fill in the properties later.
It seems related with #419. There is also support for recursive references. See example below.

Example OpenAPI:
```yaml
openapi: 3.0.3
info:
  title: 'Example'
  version: 0.1.0
servers:
  - url: 'http://example.com'
paths:
  '/foo':
    delete:
      responses:
        '200':
          description: OK
components:
  schemas:
    Matryoshka:
      type: object
      properties:
        inner_matryoshka:
          $ref: '#/components/schemas/Matryoshka'
```
From this OpenAPI generator produces following code:
```python
T = TypeVar("T", bound="Matryoshka")


@attr.s(auto_attribs=True)
class Matryoshka:
    """ """

    inner_matryoshka: Union[Unset, T] = UNSET
``` 

I didn't write tests for this PR because I want to wait for feedback first. I will do so if this strategy is approved. All but one of the current tests passed. It was removed because the behavior changed.