### PR TITLE
Feat: Schema datatypes validation by `pydantic`

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -17,6 +17,7 @@ import attr
 from ... import Config
 from ... import schema as oai
 from ... import utils
+from ...schema import DataType
 from ..errors import ParseError, PropertyError, ValidationError
 from .converter import convert, convert_chain
 from .enum_property import EnumProperty
@@ -535,9 +536,9 @@ def _property_from_data(
         return build_union_property(
             data=data, name=name, required=required, schemas=schemas, parent_name=parent_name, config=config
         )
-    if data.type == "string":
+    if data.type == DataType.STRING:
         return _string_based_property(name=name, required=required, data=data, config=config), schemas
-    if data.type == "number":
+    if data.type == DataType.NUMBER:
         return (
             FloatProperty(
                 name=name,
@@ -548,7 +549,7 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == "integer":
+    if data.type == DataType.INTEGER:
         return (
             IntProperty(
                 name=name,
@@ -559,7 +560,7 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == "boolean":
+    if data.type == DataType.BOOLEAN:
         return (
             BooleanProperty(
                 name=name,
@@ -570,26 +571,24 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == "array":
+    if data.type == DataType.ARRAY:
         return build_list_property(
             data=data, name=name, required=required, schemas=schemas, parent_name=parent_name, config=config
         )
-    if data.type == "object" or data.allOf:
+    if data.type == DataType.OBJECT or data.allOf:
         return build_model_property(
             data=data, name=name, schemas=schemas, required=required, parent_name=parent_name, config=config
         )
-    if not data.type:
-        return (
-            AnyProperty(
-                name=name,
-                required=required,
-                nullable=False,
-                default=None,
-                python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
-            ),
-            schemas,
-        )
-    return PropertyError(data=data, detail=f"unknown type {data.type}"), schemas
+    return (
+        AnyProperty(
+            name=name,
+            required=required,
+            nullable=False,
+            default=None,
+            python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
+        ),
+        schemas,
+    )
 
 
 def property_from_data(

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -17,7 +17,6 @@ import attr
 from ... import Config
 from ... import schema as oai
 from ... import utils
-from ...schema import DataType
 from ..errors import ParseError, PropertyError, ValidationError
 from .converter import convert, convert_chain
 from .enum_property import EnumProperty
@@ -536,9 +535,9 @@ def _property_from_data(
         return build_union_property(
             data=data, name=name, required=required, schemas=schemas, parent_name=parent_name, config=config
         )
-    if data.type == DataType.STRING:
+    if data.type == oai.DataType.STRING:
         return _string_based_property(name=name, required=required, data=data, config=config), schemas
-    if data.type == DataType.NUMBER:
+    if data.type == oai.DataType.NUMBER:
         return (
             FloatProperty(
                 name=name,
@@ -549,7 +548,7 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == DataType.INTEGER:
+    if data.type == oai.DataType.INTEGER:
         return (
             IntProperty(
                 name=name,
@@ -560,7 +559,7 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == DataType.BOOLEAN:
+    if data.type == oai.DataType.BOOLEAN:
         return (
             BooleanProperty(
                 name=name,
@@ -571,11 +570,11 @@ def _property_from_data(
             ),
             schemas,
         )
-    if data.type == DataType.ARRAY:
+    if data.type == oai.DataType.ARRAY:
         return build_list_property(
             data=data, name=name, required=required, schemas=schemas, parent_name=parent_name, config=config
         )
-    if data.type == DataType.OBJECT or data.allOf:
+    if data.type == oai.DataType.OBJECT or data.allOf:
         return build_model_property(
             data=data, name=name, schemas=schemas, required=required, parent_name=parent_name, config=config
         )

--- a/openapi_python_client/schema/__init__.py
+++ b/openapi_python_client/schema/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "Operation",
     "Parameter",
     "ParameterLocation",
+    "DataType",
     "PathItem",
     "Reference",
     "RequestBody",
@@ -13,6 +14,7 @@ __all__ = [
 ]
 
 
+from .data_type import DataType
 from .openapi_schema_pydantic import (
     MediaType,
     OpenAPI,

--- a/openapi_python_client/schema/data_type.py
+++ b/openapi_python_client/schema/data_type.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class DataType(str, Enum):
+    """The data type of a schema is defined by the type keyword
+
+    References:
+        - https://swagger.io/docs/specification/data-models/data-types/
+    """
+
+    STRING = "string"
+    NUMBER = "number"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+    ARRAY = "array"
+    OBJECT = "object"

--- a/openapi_python_client/schema/openapi_schema_pydantic/schema.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/schema.py
@@ -17,7 +17,7 @@ class Schema(BaseModel):
 
     References:
         - https://swagger.io/docs/specification/data-models/
-        - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject
+        - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject
     """
 
     title: Optional[str] = None

--- a/openapi_python_client/schema/openapi_schema_pydantic/schema.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/schema.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from ..data_type import DataType
 from .discriminator import Discriminator
 from .external_documentation import ExternalDocumentation
 from .reference import Reference
@@ -16,7 +17,7 @@ class Schema(BaseModel):
 
     References:
         - https://swagger.io/docs/specification/data-models/
-        - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject
+        - https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schemaObject
     """
 
     title: Optional[str] = None
@@ -35,7 +36,7 @@ class Schema(BaseModel):
     minProperties: Optional[int] = Field(default=None, ge=0)
     required: Optional[List[str]] = Field(default=None, min_items=1)
     enum: Optional[List[Any]] = Field(default=None, min_items=1)
-    type: Optional[str] = None
+    type: Optional[DataType] = Field(default=None)
     allOf: Optional[List[Union[Reference, "Schema"]]] = None
     oneOf: List[Union[Reference, "Schema"]] = []
     anyOf: List[Union[Reference, "Schema"]] = []

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -729,19 +729,6 @@ class TestBuildUnionProperty:
         assert p == expected
         assert s == Schemas()
 
-    def test_schema_bad_type(self, mocker):
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
-            oai.Schema(anyOf=[{"type": "garbage"}])
-
-        with pytest.raises(pydantic.ValidationError):
-            oai.Schema(
-                properties={
-                    "bad": oai.Schema(type="not_real"),
-                },
-            )
-
 
 class TestStringBasedProperty:
     @pytest.mark.parametrize("nullable", (True, False))

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -729,6 +729,20 @@ class TestBuildUnionProperty:
         assert p == expected
         assert s == Schemas()
 
+    def test_build_union_property_invalid_property(self, mocker):
+        name = "bad_union"
+        required = mocker.MagicMock()
+        reference = oai.Reference.construct(ref="#/components/schema/NotExist")
+        data = oai.Schema(anyOf=[reference])
+        mocker.patch("openapi_python_client.utils.remove_string_escapes", return_value=name)
+
+        from openapi_python_client.parser.properties import Schemas, build_union_property
+
+        p, s = build_union_property(
+            name=name, required=required, data=data, schemas=Schemas(), parent_name="parent", config=MagicMock()
+        )
+        assert p == PropertyError(detail=f"Invalid property in union {name}", data=reference)
+
 
 class TestStringBasedProperty:
     @pytest.mark.parametrize("nullable", (True, False))

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -140,6 +140,34 @@ class TestBuildModelProperty:
         assert new_schemas == schemas
         assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
 
+    def test_model_bad_properties(self):
+        from openapi_python_client.parser.properties import Schemas, build_model_property
+
+        data = oai.Schema(
+            properties={
+                "bad": oai.Reference.construct(ref="#/components/schema/NotExist"),
+            },
+        )
+        result = build_model_property(
+            data=data, name="prop", schemas=Schemas(), required=True, parent_name="parent", config=Config()
+        )[0]
+        assert isinstance(result, PropertyError)
+
+    def test_model_bad_additional_properties(self):
+        from openapi_python_client.parser.properties import Schemas, build_model_property
+
+        additional_properties = oai.Schema(
+            type="object",
+            properties={
+                "bad": oai.Reference(ref="#/components/schemas/not_exist"),
+            },
+        )
+        data = oai.Schema(additionalProperties=additional_properties)
+        result = build_model_property(
+            data=data, name="prop", schemas=Schemas(), required=True, parent_name="parent", config=Config()
+        )[0]
+        assert isinstance(result, PropertyError)
+
 
 class TestProcessProperties:
     def test_conflicting_properties_different_types(

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -162,6 +162,20 @@ class TestProcessProperties:
 
         assert isinstance(result, PropertyError)
 
+    def test_process_properties_reference_not_exist(self):
+        from openapi_python_client.parser.properties import Schemas
+        from openapi_python_client.parser.properties.model_property import _process_properties
+
+        data = oai.Schema(
+            properties={
+                "bad": oai.Reference.construct(ref="#/components/schema/NotExist"),
+            },
+        )
+
+        result = _process_properties(data=data, class_name="", schemas=Schemas(), config=Config())
+
+        assert isinstance(result, PropertyError)
+
     def test_invalid_reference(self, model_property_factory):
         from openapi_python_client.parser.properties import Schemas
         from openapi_python_client.parser.properties.model_property import _process_properties

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -140,42 +140,6 @@ class TestBuildModelProperty:
         assert new_schemas == schemas
         assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
 
-    def test_bad_props_return_error(self):
-        from openapi_python_client.parser.properties import Schemas, build_model_property
-
-        data = oai.Schema(
-            properties={
-                "bad": oai.Schema(type="not_real"),
-            },
-        )
-        schemas = Schemas()
-
-        err, new_schemas = build_model_property(
-            data=data, name="prop", schemas=schemas, required=True, parent_name=None, config=Config()
-        )
-
-        assert new_schemas == schemas
-        assert err == PropertyError(detail="unknown type not_real", data=oai.Schema(type="not_real"))
-
-    def test_bad_additional_props_return_error(self):
-        from openapi_python_client.parser.properties import Config, Schemas, build_model_property
-
-        additional_properties = oai.Schema(
-            type="object",
-            properties={
-                "bad": oai.Schema(type="not_real"),
-            },
-        )
-        data = oai.Schema(additionalProperties=additional_properties)
-        schemas = Schemas()
-
-        err, new_schemas = build_model_property(
-            data=data, name="prop", schemas=schemas, required=True, parent_name=None, config=Config()
-        )
-
-        assert new_schemas == schemas
-        assert err == PropertyError(detail="unknown type not_real", data=oai.Schema(type="not_real"))
-
 
 class TestProcessProperties:
     def test_conflicting_properties_different_types(

--- a/tests/test_schema/test_data_type.py
+++ b/tests/test_schema/test_data_type.py
@@ -1,4 +1,5 @@
 import pytest
+
 import openapi_python_client.schema as oai
 
 
@@ -22,7 +23,12 @@ class TestDataType:
     @pytest.mark.parametrize(
         "type_",
         (
-            "string", "number", "integer", "boolean", "array", "object",
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "object",
         ),
     )
     def test_schema_happy(self, type_):

--- a/tests/test_schema/test_data_type.py
+++ b/tests/test_schema/test_data_type.py
@@ -1,0 +1,29 @@
+import pytest
+import openapi_python_client.schema as oai
+
+
+class TestDataType:
+    def test_schema_bad_types(self):
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError):
+            oai.Schema(type="bad_type")
+
+        with pytest.raises(pydantic.ValidationError):
+            oai.Schema(anyOf=[{"type": "garbage"}])
+
+        with pytest.raises(pydantic.ValidationError):
+            oai.Schema(
+                properties={
+                    "bad": oai.Schema(type="not_real"),
+                },
+            )
+
+    @pytest.mark.parametrize(
+        "type_",
+        (
+            "string", "number", "integer", "boolean", "array", "object",
+        ),
+    )
+    def test_schema_happy(self, type_):
+        assert oai.Schema(type=type_).type == type_


### PR DESCRIPTION
A little suggestion for type checking in the `Schema`: Looks like it is a task for `pydantic` in input. This is more obvious and allows to reduce test cases.