### PR TITLE
feat: Improve error messages related to invalid arrays and circular or recursive references.

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -480,7 +480,8 @@ def build_list_property(
         name=f"{name}_item", required=True, data=data.items, schemas=schemas, parent_name=parent_name, config=config
     )
     if isinstance(inner_prop, PropertyError):
-        return PropertyError(data=inner_prop.data, detail=f"invalid data in items of array {name}"), schemas
+        inner_prop.header = f'invalid data in items of array named "{name}"'
+        return inner_prop, schemas
     return (
         ListProperty(
             name=name,

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -94,6 +94,13 @@ def update_schemas_with_data(
     )
 
     if isinstance(prop, PropertyError):
+        prop.detail = f"{prop.header}: {prop.detail}"
+        prop.header = f"Unable to parse schema {ref_path}"
+        if isinstance(prop.data, oai.Reference) and prop.data.ref.endswith(ref_path):  # pragma: nocover
+            prop.detail += (
+                "\n\nRecursive and circular references are not supported. "
+                "See https://github.com/openapi-generators/openapi-python-client/issues/466"
+            )
         return prop
 
     schemas = attr.evolve(schemas, classes_by_reference={ref_path: prop, **schemas.classes_by_reference})

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -722,7 +722,9 @@ class TestBuildListProperty:
             name=name, required=required, data=data, schemas=schemas, parent_name="parent", config=config
         )
 
-        assert p == PropertyError(data="blah", detail=f"invalid data in items of array {name}")
+        assert isinstance(p, PropertyError)
+        assert p.data == "blah"
+        assert p.header.startswith(f"invalid data in items of array {name}")
         assert new_schemas == second_schemas
         assert schemas != new_schemas, "Schema was mutated"
         property_from_data.assert_called_once_with(


### PR DESCRIPTION
Inspired by #513 which had a cryptic warning message.