### PR TITLE
fix: setup.py should generate importable packages named <project>_client (closes #520)

### DIFF
--- a/openapi_python_client/templates/setup.py.jinja
+++ b/openapi_python_client/templates/setup.py.jinja
@@ -1,6 +1,6 @@
 import pathlib
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / "README.md").read_text(encoding="utf-8")
@@ -11,8 +11,7 @@ setup(
     description="{{ package_description }}",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    package_dir={"": "{{ package_name }}"},
-    packages=find_packages(where="{{ package_name }}"),
+    packages=["{{ package_name }}"],
     python_requires=">=3.6, <4",
     install_requires=["httpx >= 0.15.0, < 0.21.0", "attrs >= 20.1.0, < 22.0.0", "python-dateutil >= 2.8.0, < 3"],
     package_data={"": ["CHANGELOG.md"], "{{ package_name }}": ["py.typed"]},


### PR DESCRIPTION
In order to allow multiple clients generated to be installed via setup.py, update the generated setup.py file so that the package installed is available to clients as
`from <my_api>_client import Client` 
rather than just
`import Client` 

This is accomplished by specifying `packages=["{{package_name}}"]` in the setup.py.jinja2 file and removing the `package_dir={"": "{{ package_name }}"},` directive.