### PR TITLE
feat: add http call logging

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Union
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -40,6 +40,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -50,6 +70,7 @@ def sync_detailed(
         common=common,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -68,6 +89,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Union
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -40,6 +40,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -50,6 +70,7 @@ def sync_detailed(
         common=common,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -68,6 +89,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Union
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling DELETE '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     param_path: str,
     *,
@@ -53,6 +73,7 @@ def sync_detailed(
         param_query=param_query,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.delete(
         **kwargs,
     )
@@ -73,6 +94,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.delete(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response
+from ...types import HTTP_CALL_LOGGER, UNSET, Response
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     param_path: str,
     *,
@@ -53,6 +73,7 @@ def sync_detailed(
         param_query=param_query,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -73,6 +94,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Union
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -49,6 +49,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     param_path: str,
     *,
@@ -65,6 +85,7 @@ def sync_detailed(
         param_cookie=param_cookie,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -89,6 +110,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -39,6 +39,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     param4: str,
     param2: int,
@@ -55,6 +75,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -79,6 +100,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -33,6 +33,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -41,6 +61,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -57,6 +78,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -8,7 +8,7 @@ from ...client import Client
 from ...models.an_enum import AnEnum
 from ...models.http_validation_error import HTTPValidationError
 from ...models.model_with_union_property import ModelWithUnionProperty
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -105,6 +105,26 @@ def _build_response(*, response: httpx.Response) -> Response[Union[Any, HTTPVali
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -135,6 +155,7 @@ def sync_detailed(
         required_model_prop=required_model_prop,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -206,6 +227,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, cast
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[List[bool]]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -49,6 +69,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -76,6 +97,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, cast
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[List[float]]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -49,6 +69,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -76,6 +97,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, cast
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[List[int]]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -49,6 +69,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -76,6 +97,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, cast
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -41,6 +41,26 @@ def _build_response(*, response: httpx.Response) -> Response[List[str]]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -49,6 +69,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -76,6 +97,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -5,7 +5,7 @@ import httpx
 from ...client import Client
 from ...models.a_model import AModel
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -51,6 +51,26 @@ def _build_response(*, response: httpx.Response) -> Response[Union[Any, HTTPVali
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -61,6 +81,7 @@ def sync_detailed(
         json_body=json_body,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -92,6 +113,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -33,6 +33,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -41,6 +61,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -57,6 +78,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from ...client import Client
-from ...types import File, Response
+from ...types import HTTP_CALL_LOGGER, File, Response
 
 
 def _get_kwargs(
@@ -42,6 +42,26 @@ def _build_response(*, response: httpx.Response) -> Response[File]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -50,6 +70,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -77,6 +98,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -4,7 +4,7 @@ import httpx
 
 from ...client import Client
 from ...models.a_form_data import AFormData
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -36,6 +36,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -46,6 +66,7 @@ def sync_detailed(
         form_data=form_data,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -64,6 +85,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -5,7 +5,7 @@ import httpx
 from ...client import Client
 from ...models.test_inline_objects_json_body import TestInlineObjectsJsonBody
 from ...models.test_inline_objects_response_200 import TestInlineObjectsResponse200
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -47,6 +47,26 @@ def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsRe
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -57,6 +77,7 @@ def sync_detailed(
         json_body=json_body,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -88,6 +109,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -36,6 +36,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -46,6 +66,7 @@ def sync_detailed(
         my_token=my_token,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -64,6 +85,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import HTTP_CALL_LOGGER, Response
 
 
 def _get_kwargs(
@@ -33,6 +33,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -41,6 +61,7 @@ def sync_detailed(
         client=client,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -57,6 +78,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -5,7 +5,7 @@ import httpx
 from ...client import Client
 from ...models.body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from ...models.http_validation_error import HTTPValidationError
-from ...types import UNSET, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -55,6 +55,26 @@ def _build_response(*, response: httpx.Response) -> Response[Union[Any, HTTPVali
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -67,6 +87,7 @@ def sync_detailed(
         keep_alive=keep_alive,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -102,6 +123,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -4,7 +4,7 @@ import httpx
 
 from ...client import Client
 from ...models.http_validation_error import HTTPValidationError
-from ...types import UNSET, File, Response, Unset
+from ...types import HTTP_CALL_LOGGER, UNSET, File, Response, Unset
 
 
 def _get_kwargs(
@@ -58,6 +58,26 @@ def _build_response(*, response: httpx.Response) -> Response[Union[Any, HTTPVali
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling POST '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -70,6 +90,7 @@ def sync_detailed(
         keep_alive=keep_alive,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.post(
         **kwargs,
     )
@@ -105,6 +126,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.post(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import httpx
 
 from ...client import Client
-from ...types import UNSET, Response
+from ...types import HTTP_CALL_LOGGER, UNSET, Response
 
 
 def _get_kwargs(
@@ -40,6 +40,26 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
     )
 
 
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
+    import json
+    import urllib.parse
+
+    url_full = kwargs["url"]
+
+    if kwargs.get("params", None):
+        url_full += "?" + urllib.parse.urlencode(kwargs["params"])
+    HTTP_CALL_LOGGER.info(f"Calling GET '{url_full}'")
+    if kwargs.get("files"):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get("dict", kwargs.get("json", None)):
+        dict_string = json.dumps(kwargs.get("dict", kwargs.get("json", None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs["cookies"])
+    headers_without_auth.pop("Authorization", None)
+    cookies, timeout = kwargs["cookies"], kwargs["timeout"]
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
+
 def sync_detailed(
     *,
     client: Client,
@@ -50,6 +70,7 @@ def sync_detailed(
         import_=import_,
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.get(
         **kwargs,
     )
@@ -68,6 +89,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.get(**kwargs)
 
     return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/types.py
@@ -1,4 +1,6 @@
 """ Contains some shared types for properties """
+import logging
+import sys
 from typing import BinaryIO, Generic, MutableMapping, Optional, TextIO, Tuple, TypeVar, Union
 
 import attr
@@ -40,4 +42,8 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["File", "Response", "FileJsonType"]
+HTTP_CALL_LOGGER = logging.getLogger(__name__.split(".")[0] + ".http_call")
+HTTP_CALL_LOGGER.setLevel(logging.WARNING)
+HTTP_CALL_LOGGER.addHandler(logging.StreamHandler(sys.stderr))
+
+__all__ = ["File", "Response", "FileJsonType", "HTTP_CALL_LOGGER"]

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response, UNSET, HTTP_CALL_LOGGER
 
 {% for relative in endpoint.relative_imports %}
 {{ relative }}
@@ -84,6 +84,23 @@ def _build_response(*, response: httpx.Response) -> Response[{{ return_string }}
         {% endif %}
     )
 
+def _log_before_call(*, kwargs: Dict[str, Any]):
+    import json
+    import urllib.parse
+    url_full = kwargs['url']
+
+    if kwargs.get('params', None):
+        url_full += '?' + urllib.parse.urlencode(kwargs['params'])
+    HTTP_CALL_LOGGER.info(f"Calling {{ endpoint.method|upper }} '{url_full}'")
+    if kwargs.get('files'):
+        HTTP_CALL_LOGGER.debug(f"with files: {kwargs['files']}")
+    elif kwargs.get('dict', kwargs.get('json', None)):
+        dict_string = json.dumps(kwargs.get('dict', kwargs.get('json', None)), indent=4, sort_keys=True)
+        HTTP_CALL_LOGGER.debug(f"with data:\n{dict_string}")
+    headers_without_auth = dict(kwargs['cookies'])
+    headers_without_auth.pop('Authorization', None)
+    cookies, timeout = kwargs['cookies'], kwargs['timeout']
+    HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
 
 def sync_detailed(
     {{ arguments(endpoint) | indent(4) }}
@@ -92,6 +109,7 @@ def sync_detailed(
         {{ kwargs(endpoint) }}
     )
 
+    _log_before_call(kwargs=kwargs)
     response = httpx.{{ endpoint.method }}(
         **kwargs,
     )
@@ -117,6 +135,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
+        _log_before_call(kwargs=kwargs)
         response = await _client.{{ endpoint.method }}(
             **kwargs
         )

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -84,7 +84,8 @@ def _build_response(*, response: httpx.Response) -> Response[{{ return_string }}
         {% endif %}
     )
 
-def _log_before_call(*, kwargs: Dict[str, Any]):
+
+def _log_before_call(*, kwargs: Dict[str, Any]) -> None:
     import json
     import urllib.parse
     url_full = kwargs['url']
@@ -101,6 +102,7 @@ def _log_before_call(*, kwargs: Dict[str, Any]):
     headers_without_auth.pop('Authorization', None)
     cookies, timeout = kwargs['cookies'], kwargs['timeout']
     HTTP_CALL_LOGGER.debug(f"{headers_without_auth=}\n{cookies=}\n{timeout=}")
+
 
 def sync_detailed(
     {{ arguments(endpoint) | indent(4) }}

--- a/openapi_python_client/templates/types.py.jinja
+++ b/openapi_python_client/templates/types.py.jinja
@@ -1,4 +1,7 @@
 """ Contains some shared types for properties """
+import sys
+import logging
+
 from typing import Any, BinaryIO, Generic, MutableMapping, Optional, TextIO, Tuple, TypeVar, Union
 
 import attr
@@ -41,4 +44,8 @@ class Response(Generic[T]):
     parsed: Optional[T]
 
 
-__all__ = ["File", "Response", "FileJsonType"]
+HTTP_CALL_LOGGER = logging.getLogger(__name__.split('.')[0]+'.http_call')
+HTTP_CALL_LOGGER.setLevel(logging.WARNING)
+HTTP_CALL_LOGGER.addHandler(logging.StreamHandler(sys.stderr))
+
+__all__ = ["File", "Response", "FileJsonType", "HTTP_CALL_LOGGER"]


### PR DESCRIPTION
httpx lets you print the http metthod and url  (without query params) and response if HTTPX_LOG_LEVEL is set to debug

```python
        status = f"{response.status_code} {response.reason_phrase}"
        response_line = f"{response.http_version} {status}"
        logger.debug(
            'HTTP Request: %s %s "%s"', request.method, request.url, response_line
        )
```
but it doesn't print headers or the body which you may want to do.
This merge request adds some logging.
I wasn't sure how to allow it via environment variable or boolean but settled on adding/using a logger
setting `types.HTTP_CALL_LOGGER.setLevel(logging.INFO)` logs the http method and url with any query params
setting `types.HTTP_CALL_LOGGER.setLevel(logging.DEBUG)` logs that plus headers/cookies/body 

P.S. Do you know of any more comprehensive openapi examples to test changes on? Especially ones that let you connect to a test server to try out commands.