### PR TITLE
Remove CHANGELOG from setup.py package_data

### DIFF
--- a/openapi_python_client/templates/setup.py.jinja
+++ b/openapi_python_client/templates/setup.py.jinja
@@ -14,5 +14,5 @@ setup(
     packages=["{{ package_name }}"],
     python_requires=">=3.6, <4",
     install_requires=["httpx >= 0.15.0, < 0.21.0", "attrs >= 20.1.0, < 22.0.0", "python-dateutil >= 2.8.0, < 3"],
-    package_data={"": ["CHANGELOG.md"], "{{ package_name }}": ["py.typed"]},
+    package_data={"{{ package_name }}": ["py.typed"]},
 )


### PR DESCRIPTION
The generator doesn't create a `CHANGELOG.md` and I haven't seen it to be a standard practice to include this in the generated wheel.