### PR TITLE
fix: Include nested packages in generated setup.py (closes #575)

### DIFF
--- a/openapi_python_client/templates/setup.py.jinja
+++ b/openapi_python_client/templates/setup.py.jinja
@@ -1,6 +1,6 @@
 import pathlib
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / "README.md").read_text(encoding="utf-8")
@@ -11,7 +11,7 @@ setup(
     description="{{ package_description }}",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=["{{ package_name }}"],
+    packages=find_packages(),
     python_requires=">=3.7, <4",
     install_requires=["httpx >= 0.15.0, < 0.22.0", "attrs >= 21.3.0", "python-dateutil >= 2.8.0, < 3"],
     package_data={"{{ package_name }}": ["py.typed"]},

--- a/openapi_python_client/templates/setup.py.jinja
+++ b/openapi_python_client/templates/setup.py.jinja
@@ -1,6 +1,6 @@
 import pathlib
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / "README.md").read_text(encoding="utf-8")


### PR DESCRIPTION
When openapi-python-client is used to with the
--meta=setup option the generated setup.py needs to
use setuptools.find_packages() to find the top-level
and all of the nested pacakges in the directory
so that distributions include them