### PR TITLE
fix: Allow tokenUrl to be relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Programmatic usage of this project (e.g., importing it as a Python module) and t
 
 The 0.x prefix used in versions for this project is to indicate that breaking changes are expected frequently (several times a year). Breaking changes will increment the minor number, all other changes will increment the patch number. You can track the progress toward 1.0 [here](https://github.com/openapi-generators/openapi-python-client/projects/2).
 
+## Current main
+
+- Relative paths are now allowed in securitySchemes/OAuthFlow/tokenUrl (#618).
+
 ## 0.11.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ Programmatic usage of this project (e.g., importing it as a Python module) and t
 
 The 0.x prefix used in versions for this project is to indicate that breaking changes are expected frequently (several times a year). Breaking changes will increment the minor number, all other changes will increment the patch number. You can track the progress toward 1.0 [here](https://github.com/openapi-generators/openapi-python-client/projects/2).
 
-## Current main
-
-- Relative paths are now allowed in securitySchemes/OAuthFlow/tokenUrl (#618).
-
 ## 0.11.1
 
 ### Features

--- a/openapi_python_client/schema/openapi_schema_pydantic/oauth_flow.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/oauth_flow.py
@@ -13,7 +13,7 @@ class OAuthFlow(BaseModel):
     """
 
     authorizationUrl: Optional[AnyUrl] = None
-    tokenUrl: Optional[AnyUrl] = None
+    tokenUrl: Optional[str] = None
     refreshUrl: Optional[AnyUrl] = None
     scopes: Dict[str, str]
 


### PR DESCRIPTION
Looks like the change before:
https://github.com/openapi-generators/openapi-python-client/commit/15c2fd5db2dd8afa6947cbf5a852a6f895f054db#diff-1a1a2865f336a376229eaffe0f56caac01c7a3a77602e07fe4a38fd550c6c318

Has been reverted:
https://github.com/openapi-generators/openapi-python-client/commit/0101a039c4f709977e136b3c0f5d186a63a7c6c5#diff-6676609c9c37705f6953ffcc9eb6d33164df50f241d4844c5665cf5ff4305995R16

As mentioned, relative URLs are supported in OpenAPI 3.0+:
https://github.com/swagger-api/swagger-ui/issues/5243