### PR TITLE
feat: CLI option to define output directory

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -56,6 +56,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         config: Config,
         custom_template_path: Optional[Path] = None,
         file_encoding: str = "utf-8",
+        output_path: Optional[Path] = None,
     ) -> None:
         self.openapi: GeneratorData = openapi
         self.meta: MetaType = meta
@@ -78,7 +79,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         )
 
         self.project_name: str = config.project_name_override or f"{utils.kebab_case(openapi.title).lower()}-client"
-        self.project_dir: Path = Path.cwd()
+        self.project_dir: Path = Path.cwd() if output_path is None else Path(output_path).absolute()
         if meta != MetaType.NONE:
             self.project_dir /= self.project_name
 
@@ -300,6 +301,7 @@ def _get_project_for_url_or_path(  # pylint: disable=too-many-arguments
     config: Config,
     custom_template_path: Optional[Path] = None,
     file_encoding: str = "utf-8",
+    output_path: Optional[Path] = None,
 ) -> Union[Project, GeneratorError]:
     data_dict = _get_document(url=url, path=path)
     if isinstance(data_dict, GeneratorError):
@@ -313,6 +315,7 @@ def _get_project_for_url_or_path(  # pylint: disable=too-many-arguments
         meta=meta,
         file_encoding=file_encoding,
         config=config,
+        output_path=output_path
     )
 
 
@@ -324,6 +327,7 @@ def create_new_client(
     config: Config,
     custom_template_path: Optional[Path] = None,
     file_encoding: str = "utf-8",
+    output_path: Optional[Path] = None,
 ) -> Sequence[GeneratorError]:
     """
     Generate the client library
@@ -338,6 +342,7 @@ def create_new_client(
         meta=meta,
         file_encoding=file_encoding,
         config=config,
+        output_path=output_path
     )
     if isinstance(project, GeneratorError):
         return [project]
@@ -352,6 +357,7 @@ def update_existing_client(
     config: Config,
     custom_template_path: Optional[Path] = None,
     file_encoding: str = "utf-8",
+    output_path: Optional[Path] = None,
 ) -> Sequence[GeneratorError]:
     """
     Update an existing client library
@@ -366,6 +372,7 @@ def update_existing_client(
         meta=meta,
         file_encoding=file_encoding,
         config=config,
+        output_path=output_path
     )
     if isinstance(project, GeneratorError):
         return [project]

--- a/openapi_python_client/cli.py
+++ b/openapi_python_client/cli.py
@@ -120,6 +120,7 @@ def generate(
     meta: MetaType = _meta_option,
     file_encoding: str = typer.Option("utf-8", help="Encoding used when writing generated"),
     config_path: Optional[pathlib.Path] = CONFIG_OPTION,
+    output_path: Optional[pathlib.Path] = typer.Option(None, help="Set a path to store the api client"),
     fail_on_warning: bool = False,
 ) -> None:
     """Generate a new OpenAPI Client library"""
@@ -146,6 +147,7 @@ def generate(
         custom_template_path=custom_template_path,
         file_encoding=file_encoding,
         config=config,
+        output_path=output_path,
     )
     handle_errors(errors, fail_on_warning)
 
@@ -159,6 +161,7 @@ def update(
     meta: MetaType = _meta_option,
     file_encoding: str = typer.Option("utf-8", help="Encoding used when writing generated"),
     config_path: Optional[pathlib.Path] = CONFIG_OPTION,
+    output_path: Optional[pathlib.Path] = typer.Option(None, help="Set a path to store the api client"),
     fail_on_warning: bool = False,
 ) -> None:
     """Update an existing OpenAPI Client library
@@ -189,5 +192,6 @@ def update(
         custom_template_path=custom_template_path,
         file_encoding=file_encoding,
         config=config,
+        output_path=output_path,
     )
     handle_errors(errors, fail_on_warning)


### PR DESCRIPTION
Not sure if I'm the only one, but I like to put (all) the generated clients together in a folder for the same project. Maybe it needs some clarification that you change the folder where the generated client is saved, not the name of the generated folder, but not sure if that is needed. If people think this is a bad idea, let me know so maybe I change my mind ;-)

- [ ] Tests
- [ ] Codestyle
- [ ] ..?
 