### PR TITLE
Remove max version from dependencies

### DIFF
--- a/openapi_python_client/templates/pyproject.toml.jinja
+++ b/openapi_python_client/templates/pyproject.toml.jinja
@@ -14,9 +14,9 @@ include = ["CHANGELOG.md", "{{ package_name }}/py.typed"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-httpx = ">=0.15.4,<0.24.0"
+httpx = ">=0.15.4"
 attrs = ">=21.3.0"
-python-dateutil = "^2.8.0"
+python-dateutil = ">=2.8.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/openapi_python_client/templates/setup.py.jinja
+++ b/openapi_python_client/templates/setup.py.jinja
@@ -13,6 +13,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     python_requires=">=3.7, <4",
-    install_requires=["httpx >= 0.15.0, < 0.24.0", "attrs >= 21.3.0", "python-dateutil >= 2.8.0, < 3"],
+    install_requires=["httpx >= 0.15.0", "attrs >= 21.3.0", "python-dateutil >= 2.8.0"],
     package_data={"{{ package_name }}": ["py.typed"]},
 )


### PR DESCRIPTION
This PR is a proof of concept to resolve #626. It removes the max version for dependencies to ensure future updates (notably security updates) are not restricted in clients generated by this library.

Additional enhancement ideas:
- Update test pipeline to matrix test a range of existing and latest versions
- Update the license/readme to clarify which versions have been tested