### PR TITLE
fix: Allow relative references in all URLs

### DIFF
--- a/openapi_python_client/schema/openapi_schema_pydantic/contact.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/contact.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import BaseModel, Extra
 
 
 class Contact(BaseModel):
@@ -12,7 +12,7 @@ class Contact(BaseModel):
     """
 
     name: Optional[str] = None
-    url: Optional[AnyUrl] = None
+    url: Optional[str] = None
     email: Optional[str] = None
 
     class Config:  # pylint: disable=missing-class-docstring

--- a/openapi_python_client/schema/openapi_schema_pydantic/external_documentation.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/external_documentation.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import BaseModel, Extra
 
 
 class ExternalDocumentation(BaseModel):
@@ -11,7 +11,7 @@ class ExternalDocumentation(BaseModel):
     """
 
     description: Optional[str] = None
-    url: AnyUrl
+    url: str
 
     class Config:  # pylint: disable=missing-class-docstring
         extra = Extra.allow

--- a/openapi_python_client/schema/openapi_schema_pydantic/info.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/info.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import BaseModel, Extra
 
 from .contact import Contact
 from .license import License
@@ -19,7 +19,7 @@ class Info(BaseModel):
 
     title: str
     description: Optional[str] = None
-    termsOfService: Optional[AnyUrl] = None
+    termsOfService: Optional[str] = None
     contact: Optional[Contact] = None
     license: Optional[License] = None
     version: str

--- a/openapi_python_client/schema/openapi_schema_pydantic/license.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/license.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import BaseModel, Extra
 
 
 class License(BaseModel):
@@ -12,7 +12,7 @@ class License(BaseModel):
     """
 
     name: str
-    url: Optional[AnyUrl] = None
+    url: Optional[str] = None
 
     class Config:  # pylint: disable=missing-class-docstring
         extra = Extra.allow

--- a/openapi_python_client/schema/openapi_schema_pydantic/oauth_flow.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/oauth_flow.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional
 
-from pydantic import AnyUrl, BaseModel, Extra
+from pydantic import BaseModel, Extra
 
 
 class OAuthFlow(BaseModel):
@@ -12,9 +12,9 @@ class OAuthFlow(BaseModel):
         - https://swagger.io/docs/specification/authentication/oauth2/
     """
 
-    authorizationUrl: Optional[AnyUrl] = None
+    authorizationUrl: Optional[str] = None
     tokenUrl: Optional[str] = None
-    refreshUrl: Optional[AnyUrl] = None
+    refreshUrl: Optional[str] = None
     scopes: Dict[str, str]
 
     class Config:  # pylint: disable=missing-class-docstring

--- a/openapi_python_client/schema/openapi_schema_pydantic/security_scheme.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/security_scheme.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field
 
 from .oauth_flows import OAuthFlows
 
@@ -26,7 +26,7 @@ class SecurityScheme(BaseModel):
     scheme: Optional[str] = None
     bearerFormat: Optional[str] = None
     flows: Optional[OAuthFlows] = None
-    openIdConnectUrl: Optional[AnyUrl] = None
+    openIdConnectUrl: Optional[str] = None
 
     class Config:  # pylint: disable=missing-class-docstring
         extra = Extra.allow


### PR DESCRIPTION
Following up from https://github.com/openapi-generators/openapi-python-client/pull/618 - this doesn't quite bring the library into compliance with the spec yet as this rule applies to *all* URLs.

https://swagger.io/specification/#relative-references-in-urls

> **Relative References in URLs**
> Unless specified otherwise, all properties that are URLs MAY be relative references as defined by [RFC3986](https://tools.ietf.org/html/rfc3986#section-4.2). Relative references are resolved using the URLs defined in the [Server Object](https://swagger.io/specification/#server-object) as a Base URI.

There aren't (as of 3.0.3) any exceptions defined to this, so this PR removes all uses of `AnyUrl` and replaces them with `str`.