### PR TITLE
Support request bodies components

### DIFF
--- a/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/tests/__init__.py
+++ b/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/tests/__init__.py
@@ -16,6 +16,7 @@ from . import (
     octet_stream_tests_octet_stream_get,
     post_form_data,
     post_form_data_inline,
+    post_form_data_ref,
     post_tests_json_body_string,
     test_inline_objects,
     token_with_cookie_auth_token_with_cookie_get,
@@ -67,6 +68,13 @@ class TestsEndpoints:
         Post form data
         """
         return post_form_data
+
+    @classmethod
+    def post_form_data_ref(cls) -> types.ModuleType:
+        """
+        Post form data (ref request body)
+        """
+        return post_form_data_ref
 
     @classmethod
     def post_form_data_inline(cls) -> types.ModuleType:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_ref.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_ref.py
@@ -1,0 +1,87 @@
+from http import HTTPStatus
+from typing import Any, Dict
+
+import httpx
+
+from ...client import Client
+from ...models.a_form_data import AFormData
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    form_data: AFormData,
+) -> Dict[str, Any]:
+    url = "{}/tests/post_form_data_ref_body".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "data": form_data.to_dict(),
+    }
+
+
+def _build_response(*, response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=None,
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    form_data: AFormData,
+) -> Response[Any]:
+    """Post form data (ref request body)
+
+     Post form data (ref request body)
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        form_data=form_data,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    form_data: AFormData,
+) -> Response[Any]:
+    """Post form data (ref request body)
+
+     Post form data (ref request body)
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        form_data=form_data,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(response=response)

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -242,6 +242,29 @@
         }
       }
     },
+    "/tests/post_form_data_ref_body": {
+      "post": {
+        "tags": [
+          "tests"
+        ],
+        "summary": "Post form data (ref request body)",
+        "description": "Post form data (ref request body)",
+        "operationId": "post_form_data_ref",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AFormBody"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/tests/post_form_data_inline": {
       "post": {
         "tags": [
@@ -756,7 +779,9 @@
     },
     "/responses/unions/simple_before_complex": {
       "post": {
-        "tags": ["responses"],
+        "tags": [
+          "responses"
+        ],
         "description": "Regression test for #603",
         "responses": {
           "200": {
@@ -765,12 +790,18 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["a"],
+                  "required": [
+                    "a"
+                  ],
                   "properties": {
                     "a": {
                       "oneOf": [
-                        {"type": "string"},
-                        {"type": "object"}
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "object"
+                        }
                       ]
                     }
                   }
@@ -877,20 +908,20 @@
       },
       "parameters": [
         {
-            "name": "param",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "param",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+          "name": "param",
+          "in": "query",
+          "schema": {
+            "type": "string"
           }
+        },
+        {
+          "name": "param",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
       ]
     },
     "/same-name-multiple-locations/{param}": {
@@ -939,7 +970,9 @@
     },
     "/tag_with_number": {
       "get": {
-        "tags": ["1"],
+        "tags": [
+          "1"
+        ],
         "responses": {
           "200": {
             "description": "Success"
@@ -1163,9 +1196,15 @@
           {
             "$ref": "#/components/parameters/integer-param"
           },
-          {"$ref": "#/components/parameters/header-param"},
-          {"$ref": "#/components/parameters/cookie-param"},
-          {"$ref": "#/components/parameters/path-param"}
+          {
+            "$ref": "#/components/parameters/header-param"
+          },
+          {
+            "$ref": "#/components/parameters/cookie-param"
+          },
+          {
+            "$ref": "#/components/parameters/path-param"
+          }
         ],
         "responses": {
           "200": {
@@ -1477,7 +1516,11 @@
       },
       "Body_upload_file_tests_upload_post": {
         "title": "Body_upload_file_tests_upload_post",
-        "required": ["some_file", "some_object", "some_nullable_object"],
+        "required": [
+          "some_file",
+          "some_object",
+          "some_nullable_object"
+        ],
         "type": "object",
         "properties": {
           "some_file": {
@@ -1519,7 +1562,10 @@
           "some_object": {
             "title": "Some Object",
             "type": "object",
-            "required": ["num", "text"],
+            "required": [
+              "num",
+              "text"
+            ],
             "properties": {
               "num": {
                 "type": "number"
@@ -1532,7 +1578,9 @@
           "some_optional_object": {
             "title": "Some Optional Object",
             "type": "object",
-            "required": ["foo"],
+            "required": [
+              "foo"
+            ],
             "properties": {
               "foo": {
                 "type": "string"
@@ -1755,7 +1803,10 @@
           },
           "type_enum": {
             "type": "integer",
-            "enum": [0, 1]
+            "enum": [
+              0,
+              1
+            ]
           }
         }
       },
@@ -1768,11 +1819,15 @@
           },
           "type": {
             "type": "string",
-            "enum": ["submodel"]
+            "enum": [
+              "submodel"
+            ]
           },
           "type_enum": {
             "type": "integer",
-            "enum": [0]
+            "enum": [
+              0
+            ]
           }
         }
       },
@@ -1915,7 +1970,7 @@
           }
         }
       },
-      "ModelWithDateTimeProperty" : {
+      "ModelWithDateTimeProperty": {
         "type": "object",
         "properties": {
           "datetime": {
@@ -2093,10 +2148,10 @@
         "type": "string",
         "format": "byte"
       },
-      "import":  {
+      "import": {
         "type": "object"
       },
-      "None":  {
+      "None": {
         "type": "object"
       },
       "model.reference.with.Periods": {
@@ -2165,6 +2220,18 @@
         "required": true,
         "schema": {
           "type": "string"
+        }
+      }
+    },
+    "requestBodies": {
+      "AFormBody": {
+        "required": true,
+        "content": {
+          "application/x-www-form-urlencoded": {
+            "schema": {
+              "$ref": "#/components/schemas/AFormData"
+            }
+          }
         }
       }
     }

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -199,7 +199,7 @@ def parameter_from_reference(
         parameters: `Parameters` up until now.
 
     Returns:
-        Either the updated `schemas` input or a `PropertyError` if something went wrong.
+        Either the updated `schemas` input or a `ParameterError` if something went wrong.
 
     See Also:
         - https://swagger.io/docs/specification/using-ref/

--- a/openapi_python_client/parser/properties/schemas.py
+++ b/openapi_python_client/parser/properties/schemas.py
@@ -16,6 +16,7 @@ import attr
 
 from ... import Config
 from ... import schema as oai
+from ...schema import RequestBody
 from ...schema.openapi_schema_pydantic import Parameter
 from ...utils import ClassName, PythonIdentifier
 from ..errors import ParameterError, ParseError, PropertyError
@@ -123,6 +124,14 @@ class Parameters:
 
     classes_by_reference: Dict[_ReferencePath, Parameter] = attr.ib(factory=dict)
     classes_by_name: Dict[ClassName, Parameter] = attr.ib(factory=dict)
+    errors: List[ParseError] = attr.ib(factory=list)
+
+
+@attr.s(auto_attribs=True, frozen=True)
+class RequestBodies:
+    """Structure for containing all defined, shareable, and reusable request bodies"""
+
+    bodies_by_reference: Dict[str, RequestBody] = attr.ib(factory=dict)
     errors: List[ParseError] = attr.ib(factory=list)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pytest
 from typer.testing import CliRunner
 
-from openapi_python_client import Config
 from openapi_python_client.parser.errors import GeneratorError, ParseError
 
 runner = CliRunner()
@@ -149,7 +148,7 @@ class TestGenerate:
     def test_generate_encoding_errors(self, _create_new_client):
         path = "cool/path"
         file_encoding = "error-file-encoding"
-        from openapi_python_client.cli import MetaType, app
+        from openapi_python_client.cli import app
 
         result = runner.invoke(app, ["generate", f"--path={path}", f"--file-encoding={file_encoding}"])
 
@@ -286,7 +285,7 @@ class TestUpdate:
     def test_update_encoding_errors(self, _update_existing_client):
         path = "cool/path"
         file_encoding = "error-file-encoding"
-        from openapi_python_client.cli import MetaType, app
+        from openapi_python_client.cli import app
 
         result = runner.invoke(app, ["update", f"--path={path}", f"--file-encoding={file_encoding}"])
 

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -338,7 +338,7 @@ class TestPropertyFromData:
         }
 
     def test_property_from_data_null_enum(self, enum_property_factory, none_property_factory):
-        from openapi_python_client.parser.properties import Class, Schemas, property_from_data
+        from openapi_python_client.parser.properties import Schemas, property_from_data
         from openapi_python_client.schema import Schema
 
         data = Schema(title="AnEnumWithOnlyNull", enum=[None], nullable=False, default=None)
@@ -459,7 +459,7 @@ class TestPropertyFromData:
         assert prop == PropertyError(data=data, detail="x is an invalid default for enum MyEnum")
 
     def test_property_from_data_ref_model(self, model_property_factory):
-        from openapi_python_client.parser.properties import Class, ModelProperty, Schemas, property_from_data
+        from openapi_python_client.parser.properties import Class, Schemas, property_from_data
 
         name = "new_name"
         required = False
@@ -646,7 +646,7 @@ class TestPropertyFromData:
         )
 
     def test_property_from_data_union_of_one_element(self, mocker, model_property_factory):
-        from openapi_python_client.parser.properties import Class, ModelProperty, Schemas, property_from_data
+        from openapi_python_client.parser.properties import Schemas, property_from_data
 
         name = "new_name"
         required = False

--- a/tests/test_parser/test_properties/test_schemas.py
+++ b/tests/test_parser/test_properties/test_schemas.py
@@ -57,7 +57,7 @@ class TestParameterFromData:
     def test_parameters_without_schema_are_ignored(self):
         from openapi_python_client.parser.properties import Parameters
         from openapi_python_client.parser.properties.schemas import parameter_from_data
-        from openapi_python_client.schema import ParameterLocation, Schema
+        from openapi_python_client.schema import ParameterLocation
 
         param = Parameter(name="a_schemaless_param", param_in=ParameterLocation.QUERY)
         parameters = Parameters()

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import openapi_python_client.schema as oai
 from openapi_python_client.parser.errors import ParseError, PropertyError
-from openapi_python_client.parser.properties import AnyProperty, Schemas, StringProperty
+from openapi_python_client.parser.properties import Schemas
 
 MODULE_NAME = "openapi_python_client.parser.responses"
 


### PR DESCRIPTION
adds support for request bodies referencing  to `components/requestBodies/<name>` (see [spec](https://swagger.io/specification/#components-object))

Fixes #595. Sorry I only found #633 after preparing this PR, but in contrast to #633 this one also updates tests (including e2e).