### PR TITLE
Make `client` argument optional in macros `kwargs` and `arguments`

### DIFF
--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -77,17 +77,21 @@ params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 {% endmacro %}
 
 {# The all the kwargs passed into an endpoint (and variants thereof)) #}
-{% macro arguments(endpoint) %}
+{% macro arguments(endpoint, include_client=True) %}
 {# path parameters #}
 {% for parameter in endpoint.path_parameters.values() %}
 {{ parameter.to_string() }},
 {% endfor %}
+{% if include_client or endpoint.form_body or endpoint.multipart_body or endpoint.json_body or endpoint.query_parameters or endpoint.header_parameters or endpoint.cookie_parameters %}
 *,
+{% endif %}
+{% if include_client%}
 {# Proper client based on whether or not the endpoint requires authentication #}
 {% if endpoint.requires_security %}
 client: AuthenticatedClient,
 {% else %}
 client: Client,
+{% endif %}
 {% endif %}
 {# Form data if any #}
 {% if endpoint.form_body %}
@@ -115,11 +119,13 @@ json_body: {{ endpoint.json_body.get_type_string() }},
 {% endmacro %}
 
 {# Just lists all kwargs to endpoints as name=name for passing to other functions #}
-{% macro kwargs(endpoint) %}
+{% macro kwargs(endpoint, include_client=True) %}
 {% for parameter in endpoint.path_parameters.values() %}
 {{ parameter.python_name }}={{ parameter.python_name }},
 {% endfor %}
+{% if include_client %}
 client=client,
+{% endif %}
 {% if endpoint.form_body %}
 form_data=form_data,
 {% endif %}


### PR DESCRIPTION
This change is useless on its own :sweat_smile:

So I'm going to give the context instead:
I'm working on a template with a custom API where the client is provided by `self._get_client()` instead of an explicit argument, which required a few tweaks to those macros:

```
@attr.s(auto_attribs=True)
class Endpoints:
    _client: Union[Client, Callable[[], Client]]

    def _get_client(self) -> Client:
        client = self._client
        if callable(client):
            client = client()
        return client

    {% for endpoint in endpoint_collection.endpoints %}
    {% set f_name = python_identifier(endpoint.name) %}
    {% set return_string = endpoint.response_type() %}
    def {{f_name}}_detailed(
        self,
        {{ arguments(endpoint, include_client=False) | indent(4) }}
    ) -> Response[{{ return_string }}]:
        {{ docstring(endpoint, return_string) | indent(4) }}

        from . import {{ f_name }} as _endpoint
        return _endpoint.sync_detailed(
            {{ kwargs(endpoint, include_client = False) }}
            client = self._get_client(),
        )
    {% endfor %}

```
