### PR TITLE
fix: If data.type is None but has data.properties, assume type is object

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -3,6 +3,8 @@
 from .a_form_data import AFormData
 from .a_model import AModel
 from .a_model_with_properties_reference_that_are_not_object import AModelWithPropertiesReferenceThatAreNotObject
+from .all_of_has_properties_but_no_type import AllOfHasPropertiesButNoType
+from .all_of_has_properties_but_no_type_type_enum import AllOfHasPropertiesButNoTypeTypeEnum
 from .all_of_sub_model import AllOfSubModel
 from .all_of_sub_model_type_enum import AllOfSubModelTypeEnum
 from .an_all_of_enum import AnAllOfEnum
@@ -53,6 +55,8 @@ from .validation_error import ValidationError
 
 __all__ = (
     "AFormData",
+    "AllOfHasPropertiesButNoType",
+    "AllOfHasPropertiesButNoTypeTypeEnum",
     "AllOfSubModel",
     "AllOfSubModelTypeEnum",
     "AModel",

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type.py
@@ -1,0 +1,81 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.all_of_has_properties_but_no_type_type_enum import AllOfHasPropertiesButNoTypeTypeEnum
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AllOfHasPropertiesButNoType")
+
+
+@attr.s(auto_attribs=True)
+class AllOfHasPropertiesButNoType:
+    """
+    Attributes:
+        a_sub_property (Union[Unset, str]):
+        type (Union[Unset, str]):
+        type_enum (Union[Unset, AllOfHasPropertiesButNoTypeTypeEnum]):
+    """
+
+    a_sub_property: Union[Unset, str] = UNSET
+    type: Union[Unset, str] = UNSET
+    type_enum: Union[Unset, AllOfHasPropertiesButNoTypeTypeEnum] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        a_sub_property = self.a_sub_property
+        type = self.type
+        type_enum: Union[Unset, int] = UNSET
+        if not isinstance(self.type_enum, Unset):
+            type_enum = self.type_enum.value
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if a_sub_property is not UNSET:
+            field_dict["a_sub_property"] = a_sub_property
+        if type is not UNSET:
+            field_dict["type"] = type
+        if type_enum is not UNSET:
+            field_dict["type_enum"] = type_enum
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        a_sub_property = d.pop("a_sub_property", UNSET)
+
+        type = d.pop("type", UNSET)
+
+        _type_enum = d.pop("type_enum", UNSET)
+        type_enum: Union[Unset, AllOfHasPropertiesButNoTypeTypeEnum]
+        if isinstance(_type_enum, Unset):
+            type_enum = UNSET
+        else:
+            type_enum = AllOfHasPropertiesButNoTypeTypeEnum(_type_enum)
+
+        all_of_has_properties_but_no_type = cls(
+            a_sub_property=a_sub_property,
+            type=type,
+            type_enum=type_enum,
+        )
+
+        all_of_has_properties_but_no_type.additional_properties = d
+        return all_of_has_properties_but_no_type
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class AllOfHasPropertiesButNoTypeTypeEnum(IntEnum):
+    VALUE_0 = 0
+    VALUE_1 = 1
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -1776,6 +1776,21 @@
           }
         }
       },
+      "AllOfHasPropertiesButNoType": {
+        "title": "AllOfHasPropertiesButNoType",
+        "properties": {
+          "a_sub_property": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "type_enum": {
+            "type": "integer",
+            "enum": [0, 1]
+          }
+        }
+      },
       "model_reference_doesnt_match": {
         "title": "ModelName",
         "type": "object"

--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -646,7 +646,7 @@ def _property_from_data(
         return build_list_property(
             data=data, name=name, required=required, schemas=schemas, parent_name=parent_name, config=config
         )
-    if data.type == oai.DataType.OBJECT or data.allOf:
+    if data.type == oai.DataType.OBJECT or data.allOf or (data.type is None and data.properties):
         return build_model_property(
             data=data, name=name, schemas=schemas, required=required, parent_name=parent_name, config=config
         )


### PR DESCRIPTION
Closes https://github.com/openapi-generators/openapi-python-client/issues/674

Not entirely sure if I did the end to end testing correctly since I got:
```
end_to_end_tests: task regen
Generating my-test-api-client

Usage: openapi-python-client update [OPTIONS]
Try 'openapi-python-client update --help' for help.
╭─ Error ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value: Unable to parse config
```

But it generated the test files and the task e2e succeeded.