### PR TITLE
Add support for yang-data+json content type

### DIFF
--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -25,6 +25,7 @@ _SOURCE_BY_CONTENT_TYPE = {
     "application/json": "response.json()",
     "application/vnd.api+json": "response.json()",
     "application/octet-stream": "response.content",
+    "application/yang-data+json": "response.json()",
     "text/html": "response.text",
 }
 


### PR DESCRIPTION
Fix error
```
WARNING parsing GET /restconf/data/ietf-snmp:snmp within ietf_snmp.

Cannot parse response for status code 200 (Unsupported content_type {'application/yang-data+json': MediaType(media_type_schema=Reference(ref='#/components/schemas/get_ietf_snmp_snmp'), example=None, examples=None, encoding=None)}), response will be ommitted from generated client
```
When using SONiC OS REST OpenAPI.