### PR TITLE
Allow case sensitive enum values

### DIFF
--- a/.changeset/allow_case_sensitive_enum_values.md
+++ b/.changeset/allow_case_sensitive_enum_values.md
@@ -1,0 +1,13 @@
+---
+default: major
+---
+
+# Allow case sensitive enum values
+
+#725 by @expobrain
+
+Added setting `case_sensitive_enums` to allow case sensitive enum values in the generated code.
+
+This solve the issue in #587 .
+
+Also, to avoid collisions, changes the prefix for values not starting with alphanumeric characters from `VALUE_` to `LITERAL_`.

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -43,6 +43,7 @@ class ConfigFile(BaseModel):
     post_hooks: Optional[List[str]] = None
     field_prefix: str = "field_"
     http_timeout: int = 5
+    case_sensitive_enums: bool = False
 
     @staticmethod
     def load_from_path(path: Path) -> "ConfigFile":
@@ -75,6 +76,7 @@ class Config:
     content_type_overrides: Dict[str, str]
     overwrite: bool
     output_path: Optional[Path]
+    case_sensitive_enums: bool
 
     @staticmethod
     def from_sources(
@@ -113,5 +115,6 @@ class Config:
             file_encoding=file_encoding,
             overwrite=overwrite,
             output_path=output_path,
+            case_sensitive_enums=config_file.case_sensitive_enums,
         )
         return config

--- a/openapi_python_client/parser/properties/enum_property.py
+++ b/openapi_python_client/parser/properties/enum_property.py
@@ -198,7 +198,7 @@ class EnumProperty(PropertyProtocol):
                 continue
 
             if case_sensitive_enums:
-                sanitized_key = utils.case_insensitive_snake_case(value)
+                sanitized_key = utils.case_sensitive_snake_case(value)
             else:
                 sanitized_key = utils.snake_case(value.lower()).upper()
             if not value or not value[0].isalpha():

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -77,7 +77,7 @@ def fix_reserved_words(value: str) -> str:
     return value
 
 
-def case_insensitive_snake_case(value: str) -> str:
+def case_sensitive_snake_case(value: str) -> str:
     """Converts to snake_case, but preserves capitalization of acronyms"""
     words = split_words(sanitize(value))
     value = "_".join(words)
@@ -87,7 +87,7 @@ def case_insensitive_snake_case(value: str) -> str:
 
 def snake_case(value: str) -> str:
     """Converts to snake_case"""
-    value = case_insensitive_snake_case(value).lower()
+    value = case_sensitive_snake_case(value).lower()
 
     return value
 

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -77,10 +77,19 @@ def fix_reserved_words(value: str) -> str:
     return value
 
 
+def case_insensitive_snake_case(value: str) -> str:
+    """Converts to snake_case, but preserves capitalization of acronyms"""
+    words = split_words(sanitize(value))
+    value = "_".join(words)
+
+    return value
+
+
 def snake_case(value: str) -> str:
     """Converts to snake_case"""
-    words = split_words(sanitize(value))
-    return "_".join(words).lower()
+    value = case_insensitive_snake_case(value).lower()
+
+    return value
 
 
 def pascal_case(value: str) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,7 @@ def test_load_from_path(tmp_path: Path, filename, dump, relative):
         "project_name_override": "project-name",
         "package_name_override": "package_name",
         "package_version_override": "package_version",
+        "case_sensitive_enums": True,
     }
     yml_file.write_text(dump(data))
 
@@ -49,3 +50,4 @@ def test_load_from_path(tmp_path: Path, filename, dump, relative):
     assert config.project_name_override == "project-name"
     assert config.package_name_override == "package_name"
     assert config.package_version_override == "package_version"
+    assert config.case_sensitive_enums is True

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -355,13 +355,32 @@ class TestEnumProperty:
 
         assert result == {
             "ABC": "abc",
-            "VALUE_1": "123",
+            "LITERAL_123": "123",
             "A23": "a23",
-            "VALUE_3": "1bc",
+            "LITERAL_1BC": "1bc",
             "VALUE_4": 4,
             "VALUE_NEGATIVE_3": -3,
             "A_THING_WITH_SPACES": "a Thing WIth spaces",
-            "VALUE_7": "",
+            "LITERAL_": "",
+        }
+
+    def test_values_from_list_with_case_sesitive(self):
+        from openapi_python_client.parser.properties import EnumProperty
+
+        data = ["abc", "Abc", "123", "a23", "1bc", 4, -3, "a Thing WIth spaces", ""]
+
+        result = EnumProperty.values_from_list(data, case_sensitive_enums=True)
+
+        assert result == {
+            "abc": "abc",
+            "Abc": "Abc",
+            "LITERAL_123": "123",
+            "a23": "a23",
+            "LITERAL_1bc": "1bc",
+            "VALUE_4": 4,
+            "VALUE_NEGATIVE_3": -3,
+            "a_Thing_W_Ith_spaces": "a Thing WIth spaces",
+            "LITERAL_": "",
         }
 
     def test_values_from_list_duplicate(self):


### PR DESCRIPTION
Added setting `case_sensitive_enums` to allow case sensitive enum values in the generated code.

This solve the issue in #587 .

Also, to avoid collisions, changes the prefix for values not starting with alphanumeric characters from `VALUE_` to `LITERAL_`.

### How could it happen

Consider the case `[1, "1bc"]`, the previous code would assign the enum `VALUE_1` to the first item (aka the `VALUE_` prefix plus the int value of the item) and the same enum `VALUE_1` for the second item (the prefix `VALUE_` plus the position of the non-alphanumeric value in the list).

The new code avoids that and use different prefixes for integer values (`VALUE_{value}`) and string starting with non-alphanumeric  characters (`LITERAL_{sanitised_value}`).

