### PR TITLE
fix: Parsing endpoint content types with semicolon separator

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 from .. import schema as oai
 from .. import utils
 from ..config import Config
-from ..utils import PythonIdentifier
+from ..utils import PythonIdentifier, get_content_type
 from .errors import GeneratorError, ParseError, PropertyError
 from .properties import (
     Class,
@@ -178,6 +178,8 @@ class Endpoint:
         """Return json_body"""
         json_body = None
         for content_type, schema in body.content.items():
+            content_type = get_content_type(content_type)
+
             if content_type == "application/json" or content_type.endswith("+json"):
                 json_body = schema
                 break

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -1,5 +1,6 @@
 import builtins
 import re
+from email.message import Message
 from keyword import iskeyword
 from typing import Any, List
 
@@ -94,3 +95,15 @@ def remove_string_escapes(value: str) -> str:
         - https://github.com/openapi-generators/openapi-python-client/security/advisories/GHSA-9x4c-63pf-525f
     """
     return value.replace('"', r"\"")
+
+
+def get_content_type(content_type: str) -> str:
+    """
+    Given a string representing a conten type with optional parameters, returns the content type only
+    """
+    message = Message()
+    message.add_header("Content-Type", content_type)
+
+    content_type = message.get_content_type()
+
+    return content_type

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -99,7 +99,7 @@ def remove_string_escapes(value: str) -> str:
 
 def get_content_type(content_type: str) -> str:
     """
-    Given a string representing a conten type with optional parameters, returns the content type only
+    Given a string representing a content type with optional parameters, returns the content type only
     """
     message = Message()
     message.add_header("Content-Type", content_type)

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -247,7 +247,13 @@ class TestEndpoint:
         assert prop is None
 
     @pytest.mark.parametrize(
-        "content_type", ("application/json", "application/vnd.api+json", "application/yang-data+json")
+        "content_type",
+        (
+            "application/json",
+            "application/vnd.api+json",
+            "application/yang-data+json",
+            "application/json;charset=utf-8",
+        ),
     )
     def test_parse_request_json_body(self, mocker, content_type):
         from openapi_python_client.parser.openapi import Endpoint, Schemas

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,3 +121,16 @@ def test__fix_reserved_words(reserved_word: str, expected: str):
 )
 def test_pascalcase(before, after):
     assert utils.pascal_case(before) == after
+
+
+@pytest.mark.parametrize(
+    "content_type, expected",
+    [
+        pytest.param("application/json", "application/json"),
+        pytest.param("application/vnd.api+json", "application/vnd.api+json"),
+        pytest.param("application/json;charset=utf-8", "application/json"),
+        pytest.param("application/vnd.api+json;charset=utf-8", "application/vnd.api+json"),
+    ],
+)
+def test_get_content_type(content_type: str, expected: str) -> None:
+    assert utils.get_content_type(content_type) == expected


### PR DESCRIPTION
This PR allows to extract the content type safely removing any extra parameter like `charset` or `boundary`.