### PR TITLE
Introduce `raise_on_error_status` flag

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -36,10 +36,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -61,6 +64,7 @@ def sync_detailed(
         common (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -91,6 +95,7 @@ async def asyncio_detailed(
         common (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -36,10 +36,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -61,6 +64,7 @@ def sync_detailed(
         common (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -91,6 +95,7 @@ async def asyncio_detailed(
         common (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -55,10 +55,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -90,6 +93,7 @@ def sync_detailed(
         string_enum_header (Union[Unset, GetLocationHeaderTypesStringEnumHeader]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -135,6 +139,7 @@ async def asyncio_detailed(
         string_enum_header (Union[Unset, GetLocationHeaderTypesStringEnumHeader]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -60,10 +60,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -91,6 +94,7 @@ def sync_detailed(
         not_null_not_required (Union[Unset, None, datetime.datetime]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +134,7 @@ async def asyncio_detailed(
         not_null_not_required (Union[Unset, None, datetime.datetime]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -46,10 +46,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -80,6 +83,7 @@ def sync_detailed(
         cookie_param (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -123,6 +127,7 @@ async def asyncio_detailed(
         cookie_param (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -37,10 +37,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -64,6 +67,7 @@ def sync_detailed(
         param_query (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -97,6 +101,7 @@ async def asyncio_detailed(
         param_query (Union[Unset, None, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -45,10 +45,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -76,6 +79,7 @@ def sync_detailed(
         param_cookie (Union[Unset, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -115,6 +119,7 @@ async def asyncio_detailed(
         param_cookie (Union[Unset, str]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -35,10 +35,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -66,6 +69,7 @@ def sync_detailed(
         param3 (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -105,6 +109,7 @@ async def asyncio_detailed(
         param3 (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
@@ -36,10 +36,13 @@ def _parse_response(
         response_200 = PostResponsesUnionsSimpleBeforeComplexResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(
@@ -60,6 +63,7 @@ def sync_detailed(
     """Regression test for #603
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -86,6 +90,7 @@ def sync(
     """Regression test for #603
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -105,6 +110,7 @@ async def asyncio_detailed(
     """Regression test for #603
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -129,6 +135,7 @@ async def asyncio(
     """Regression test for #603
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -29,10 +29,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -50,6 +53,7 @@ def sync_detailed(
 ) -> Response[Any]:
     """
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -75,6 +79,7 @@ async def asyncio_detailed(
 ) -> Response[Any]:
     """
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -39,11 +39,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
@@ -68,6 +73,7 @@ def sync_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -101,6 +107,7 @@ def sync(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -127,6 +134,7 @@ async def asyncio_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -158,6 +166,7 @@ async def asyncio(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -106,11 +106,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
@@ -153,6 +158,7 @@ def sync_detailed(
         required_model_prop (ModelWithUnionProperty):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -214,6 +220,7 @@ def sync(
         required_model_prop (ModelWithUnionProperty):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -268,6 +275,7 @@ async def asyncio_detailed(
         required_model_prop (ModelWithUnionProperty):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -327,6 +335,7 @@ async def asyncio(
         required_model_prop (ModelWithUnionProperty):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -31,10 +31,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         response_200 = cast(List[bool], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List[bool]]:
@@ -55,6 +58,7 @@ def sync_detailed(
      Get a list of booleans
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -83,6 +87,7 @@ def sync(
      Get a list of booleans
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -104,6 +109,7 @@ async def asyncio_detailed(
      Get a list of booleans
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +136,7 @@ async def asyncio(
      Get a list of booleans
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -31,10 +31,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         response_200 = cast(List[float], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List[float]]:
@@ -55,6 +58,7 @@ def sync_detailed(
      Get a list of floats
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -83,6 +87,7 @@ def sync(
      Get a list of floats
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -104,6 +109,7 @@ async def asyncio_detailed(
      Get a list of floats
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +136,7 @@ async def asyncio(
      Get a list of floats
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -31,10 +31,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         response_200 = cast(List[int], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List[int]]:
@@ -55,6 +58,7 @@ def sync_detailed(
      Get a list of integers
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -83,6 +87,7 @@ def sync(
      Get a list of integers
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -104,6 +109,7 @@ async def asyncio_detailed(
      Get a list of integers
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +136,7 @@ async def asyncio(
      Get a list of integers
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -31,10 +31,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         response_200 = cast(List[str], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[List[str]]:
@@ -55,6 +58,7 @@ def sync_detailed(
      Get a list of strings
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -83,6 +87,7 @@ def sync(
      Get a list of strings
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -104,6 +109,7 @@ async def asyncio_detailed(
      Get a list of strings
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +136,7 @@ async def asyncio(
      Get a list of strings
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -39,11 +39,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
@@ -68,6 +73,7 @@ def sync_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -101,6 +107,7 @@ def sync(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -127,6 +134,7 @@ async def asyncio_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -158,6 +166,7 @@ async def asyncio(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -29,10 +29,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -51,6 +54,7 @@ def sync_detailed(
     """No Response
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -77,6 +81,7 @@ async def asyncio_detailed(
     """No Response
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -32,10 +32,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Fil
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[File]:
@@ -54,6 +57,7 @@ def sync_detailed(
     """Octet Stream
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -80,6 +84,7 @@ def sync(
     """Octet Stream
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -99,6 +104,7 @@ async def asyncio_detailed(
     """Octet Stream
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -123,6 +129,7 @@ async def asyncio(
     """Octet Stream
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -32,10 +32,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -57,6 +60,7 @@ def sync_detailed(
      Post form data
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -87,6 +91,7 @@ async def asyncio_detailed(
      Post form data
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -32,10 +32,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -57,6 +60,7 @@ def sync_detailed(
      Post form data (inline schema)
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -87,6 +91,7 @@ async def asyncio_detailed(
      Post form data (inline schema)
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
@@ -38,11 +38,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[HTTPValidationError, str]]:
@@ -65,6 +70,7 @@ def sync_detailed(
         json_body (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -96,6 +102,7 @@ def sync(
         json_body (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -120,6 +127,7 @@ async def asyncio_detailed(
         json_body (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -149,6 +157,7 @@ async def asyncio(
         json_body (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -37,10 +37,13 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Tes
         response_200 = TestInlineObjectsResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[TestInlineObjectsResponse200]:
@@ -63,6 +66,7 @@ def sync_detailed(
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -94,6 +98,7 @@ def sync(
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -118,6 +123,7 @@ async def asyncio_detailed(
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -147,6 +153,7 @@ async def asyncio(
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -33,11 +33,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
     if response.status_code == HTTPStatus.OK:
         return None
     if response.status_code == HTTPStatus.UNAUTHORIZED:
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -62,6 +67,7 @@ def sync_detailed(
         my_token (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -95,6 +101,7 @@ async def asyncio_detailed(
         my_token (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -29,10 +29,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -51,6 +54,7 @@ def sync_detailed(
     """Unsupported Content
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -77,6 +81,7 @@ async def asyncio_detailed(
     """Unsupported Content
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -39,11 +39,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
@@ -68,6 +73,7 @@ def sync_detailed(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -101,6 +107,7 @@ def sync(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -127,6 +134,7 @@ async def asyncio_detailed(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -158,6 +166,7 @@ async def asyncio(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -42,11 +42,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
@@ -71,6 +76,7 @@ def sync_detailed(
         multipart_data (List[File]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -104,6 +110,7 @@ def sync(
         multipart_data (List[File]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -130,6 +137,7 @@ async def asyncio_detailed(
         multipart_data (List[File]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -161,6 +169,7 @@ async def asyncio(
         multipart_data (List[File]):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -36,10 +36,13 @@ def _get_kwargs(
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
@@ -61,6 +64,7 @@ def sync_detailed(
         import_ (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -91,6 +95,7 @@ async def asyncio_detailed(
         import_ (str):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/end_to_end_tests/golden-record/my_test_api_client/client.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/client.py
@@ -16,8 +16,10 @@ class Client:
             httpx.TimeoutException if this is exceeded.
         verify_ssl: Whether or not to verify the SSL certificate of the API server. This should be True in production,
             but can be set to False for testing purposes.
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
-            status code that was not documented in the source OpenAPI document.
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a status code
+            that was not documented in the source OpenAPI document. Can be combined with `raise_on_error_status`.
+        raise_on_error_status: Whether or not to raise an errors.ErrorStatus on all status codes >= 400, regardless of
+            whether they are expected or not. Can be combined with `raise_on_unexpected_status`.
     """
 
     base_url: str
@@ -26,6 +28,7 @@ class Client:
     timeout: float = attr.ib(5.0, kw_only=True)
     verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
     raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
+    raise_on_error_status: bool = attr.ib(False, kw_only=True)
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""

--- a/end_to_end_tests/golden-record/my_test_api_client/errors.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/errors.py
@@ -2,9 +2,29 @@
 
 
 class UnexpectedStatus(Exception):
-    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
-
-    ...
+    """Raised by api functions when the response status is undocumented and Client.raise_on_unexpected_status is True"""
 
 
-__all__ = ["UnexpectedStatus"]
+class ErrorStatus(Exception):
+    """Raised by api functions when the response status marks an error"""
+
+
+class ExpectedErrorStatus(ErrorStatus):
+    pass
+
+
+class UnexpectedErrorStatus(ErrorStatus, UnexpectedStatus):
+    pass
+
+
+class UnexpectedSuccessStatus(UnexpectedStatus):
+    pass
+
+
+__all__ = [
+    "ErrorStatus",
+    "ExpectedErrorStatus",
+    "UnexpectedErrorStatus",
+    "UnexpectedStatus",
+    "UnexpectedSuccessStatus",
+]

--- a/integration-tests/integration_tests/api/body/post_body_multipart.py
+++ b/integration-tests/integration_tests/api/body/post_body_multipart.py
@@ -43,11 +43,16 @@ def _parse_response(
     if response.status_code == HTTPStatus.BAD_REQUEST:
         response_400 = PublicError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(
@@ -71,6 +76,7 @@ def sync_detailed(
         multipart_data (PostBodyMultipartMultipartData):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -101,6 +107,7 @@ def sync(
         multipart_data (PostBodyMultipartMultipartData):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -124,6 +131,7 @@ async def asyncio_detailed(
         multipart_data (PostBodyMultipartMultipartData):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -152,6 +160,7 @@ async def asyncio(
         multipart_data (PostBodyMultipartMultipartData):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/integration-tests/integration_tests/api/parameters/post_parameters_header.py
+++ b/integration-tests/integration_tests/api/parameters/post_parameters_header.py
@@ -50,11 +50,16 @@ def _parse_response(
     if response.status_code == HTTPStatus.BAD_REQUEST:
         response_400 = PublicError.from_dict(response.json())
 
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
         return response_400
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(
@@ -84,6 +89,7 @@ def sync_detailed(
         integer_header (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -123,6 +129,7 @@ def sync(
         integer_header (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -155,6 +162,7 @@ async def asyncio_detailed(
         integer_header (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
@@ -192,6 +200,7 @@ async def asyncio(
         integer_header (int):
 
     Raises:
+        errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/integration-tests/integration_tests/client.py
+++ b/integration-tests/integration_tests/client.py
@@ -16,8 +16,10 @@ class Client:
             httpx.TimeoutException if this is exceeded.
         verify_ssl: Whether or not to verify the SSL certificate of the API server. This should be True in production,
             but can be set to False for testing purposes.
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
-            status code that was not documented in the source OpenAPI document.
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a status code
+            that was not documented in the source OpenAPI document. Can be combined with `raise_on_error_status`.
+        raise_on_error_status: Whether or not to raise an errors.ErrorStatus on all status codes >= 400, regardless of
+            whether they are expected or not. Can be combined with `raise_on_unexpected_status`.
     """
 
     base_url: str
@@ -26,6 +28,7 @@ class Client:
     timeout: float = attr.ib(5.0, kw_only=True)
     verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
     raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
+    raise_on_error_status: bool = attr.ib(False, kw_only=True)
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in all endpoints"""

--- a/integration-tests/integration_tests/errors.py
+++ b/integration-tests/integration_tests/errors.py
@@ -2,9 +2,29 @@
 
 
 class UnexpectedStatus(Exception):
-    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
-
-    ...
+    """Raised by api functions when the response status is undocumented and Client.raise_on_unexpected_status is True"""
 
 
-__all__ = ["UnexpectedStatus"]
+class ErrorStatus(Exception):
+    """Raised by api functions when the response status marks an error"""
+
+
+class ExpectedErrorStatus(ErrorStatus):
+    pass
+
+
+class UnexpectedErrorStatus(ErrorStatus, UnexpectedStatus):
+    pass
+
+
+class UnexpectedSuccessStatus(UnexpectedStatus):
+    pass
+
+
+__all__ = [
+    "ErrorStatus",
+    "ExpectedErrorStatus",
+    "UnexpectedErrorStatus",
+    "UnexpectedStatus",
+    "UnexpectedSuccessStatus",
+]

--- a/openapi_python_client/templates/client.py.jinja
+++ b/openapi_python_client/templates/client.py.jinja
@@ -14,8 +14,10 @@ class Client:
             httpx.TimeoutException if this is exceeded.
         verify_ssl: Whether or not to verify the SSL certificate of the API server. This should be True in production,
             but can be set to False for testing purposes.
-        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
-            status code that was not documented in the source OpenAPI document.
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a status code
+            that was not documented in the source OpenAPI document. Can be combined with `raise_on_error_status`.
+        raise_on_error_status: Whether or not to raise an errors.ErrorStatus on all status codes >= 400, regardless of
+            whether they are expected or not. Can be combined with `raise_on_unexpected_status`.
     """
 
     base_url: str
@@ -24,6 +26,7 @@ class Client:
     timeout: float = attr.ib(5.0, kw_only=True)
     verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
     raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
+    raise_on_error_status: bool = attr.ib(False, kw_only=True)
 
     def get_headers(self) -> Dict[str, str]:
         """ Get headers to be used in all endpoints """

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -160,6 +160,7 @@ Args:
 
 {% endif %}
 Raises:
+    errors.ErrorStatus: If the server returns an error status code and Client.raise_on_error_status is True.
     errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
     httpx.TimeoutException: If the request takes longer than Client.timeout.
 

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -68,15 +68,26 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[{{ 
         {% else %}
         {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source }})
         {% endif %}
+        {% if response.status_code >= 400 %}
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
+        {% endif %}
         return {{ response.prop.python_name }}
         {% else %}
+        {% if response.status_code >= 400 %}
+        if client.raise_on_error_status:
+            raise errors.ExpectedErrorStatus(f"Failed status code: {response.status_code}")
+        {% endif %}
         return None
         {% endif %}
     {% endfor %}
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(f"Unexpected status code: {response.status_code}")
+    if response.status_code >= 400:
+        if client.raise_on_unexpected_status or client.raise_on_error_status:
+            raise errors.UnexpectedErrorStatus(f"Unexpected status code: {response.status_code}")
     else:
-        return None
+        if client.raise_on_unexpected_status:
+            raise errors.UnexpectedSuccessStatus(f"Unexpected status code: {response.status_code}")
+    return None
 
 
 def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ return_string }}]:

--- a/openapi_python_client/templates/errors.py.jinja
+++ b/openapi_python_client/templates/errors.py.jinja
@@ -1,7 +1,30 @@
 """ Contains shared errors types that can be raised from API functions """
 
-class UnexpectedStatus(Exception):
-    """ Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True """
-    ...
 
-__all__ = ["UnexpectedStatus"]
+class UnexpectedStatus(Exception):
+    """ Raised by api functions when the response status is undocumented and Client.raise_on_unexpected_status is True """
+
+
+class ErrorStatus(Exception):
+    """ Raised by api functions when the response status marks an error """
+
+
+class ExpectedErrorStatus(ErrorStatus):
+    pass
+
+
+class UnexpectedErrorStatus(ErrorStatus, UnexpectedStatus):
+    pass
+
+
+class UnexpectedSuccessStatus(UnexpectedStatus):
+    pass
+
+
+__all__ = [
+    "ErrorStatus",
+    "ExpectedErrorStatus",
+    "UnexpectedErrorStatus",
+    "UnexpectedStatus",
+    "UnexpectedSuccessStatus",
+]


### PR DESCRIPTION
Closes https://github.com/openapi-generators/openapi-python-client/issues/491

This behaves similarly to `raise_on_unexpected_status` introduced in https://github.com/openapi-generators/openapi-python-client/pull/593.

Partially implements and inspired by the "Ability to raise exception for failed responses" from https://github.com/openapi-generators/openapi-python-client/pull/722, but I decided to go for a much simpler implementation without an `x-response-type` property. I'm not sure it is useful to go against the standard that error codes are 4xx and 5xx.

This will conflict with https://github.com/openapi-generators/openapi-python-client/pull/729. To combine both, we need to introduce a common base class for the different exception types, e.g. `ApiException`, that handles the extra arguments.