### PR TITLE
feat: Add two generation config flags to raise exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,24 @@ By default, the timeout for retrieving the schema file via HTTP is 5 seconds. In
 
 [changelog.md]: CHANGELOG.md
 [poetry]: https://python-poetry.org/
+
+### raise_on_error_status
+
+If true, generated endpoint functions raise exceptions on error response codes (status code >= 400).
+
+If false (the default), the parsed response content is returned in the same way both for success and error responses.
+
+Enabling this option also removes the error response types from the return type annotations. 
+
+For now, the raised exceptions do not include the parsed response content even if the response code has a schema in the OpenAPI spec.
+
+### raise_on_unexpected_status
+
+Enable this to raise exceptions on undocumented response codes in all generated API call functions. 
+
+By default, undocumented response content is parsed as `None`.
+
+Enabling this option also removes `None` from the return type annotations. 
+
+This option has identical behavior to setting `Client.raise_on_unexpected_status`, but setting it at
+client generation time results in simpler generated code and correct type annotations.

--- a/end_to_end_tests/config.yml
+++ b/end_to_end_tests/config.yml
@@ -9,3 +9,5 @@ class_overrides:
     class_name: AnEnumValue
     module_name: an_enum_value
 field_prefix: attr_
+raise_on_error_status: True
+raise_on_unexpected_status: True

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -48,7 +48,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +56,7 @@ def sync_detailed(
     *,
     client: Client,
     common: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         common (Union[Unset, None, str]):
@@ -66,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -86,7 +86,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     common: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         common (Union[Unset, None, str]):
@@ -96,7 +96,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -48,7 +48,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +56,7 @@ def sync_detailed(
     *,
     client: Client,
     common: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         common (Union[Unset, None, str]):
@@ -66,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -86,7 +86,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     common: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         common (Union[Unset, None, str]):
@@ -96,7 +96,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -67,7 +67,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -53,7 +53,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -62,7 +62,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -80,7 +80,7 @@ def sync_detailed(
     integer_header: Union[Unset, int] = UNSET,
     int_enum_header: Union[Unset, GetLocationHeaderTypesIntEnumHeader] = UNSET,
     string_enum_header: Union[Unset, GetLocationHeaderTypesStringEnumHeader] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         boolean_header (Union[Unset, bool]):
@@ -95,7 +95,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
     integer_header: Union[Unset, int] = UNSET,
     int_enum_header: Union[Unset, GetLocationHeaderTypesIntEnumHeader] = UNSET,
     string_enum_header: Union[Unset, GetLocationHeaderTypesStringEnumHeader] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         boolean_header (Union[Unset, bool]):
@@ -140,7 +140,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -53,7 +53,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -53,21 +53,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -91,7 +89,8 @@ def sync_detailed(
         string_enum_header (Union[Unset, GetLocationHeaderTypesStringEnumHeader]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -113,7 +112,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -136,7 +135,8 @@ async def asyncio_detailed(
         string_enum_header (Union[Unset, GetLocationHeaderTypesStringEnumHeader]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -156,4 +156,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -72,7 +72,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -58,7 +58,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -58,7 +58,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -67,7 +67,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -83,7 +83,7 @@ def sync_detailed(
     null_required: Union[Unset, None, datetime.datetime] = UNSET,
     null_not_required: Union[Unset, None, datetime.datetime] = UNSET,
     not_null_not_required: Union[Unset, None, datetime.datetime] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         not_null_required (datetime.datetime):
@@ -96,7 +96,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -122,7 +122,7 @@ async def asyncio_detailed(
     null_required: Union[Unset, None, datetime.datetime] = UNSET,
     null_not_required: Union[Unset, None, datetime.datetime] = UNSET,
     not_null_not_required: Union[Unset, None, datetime.datetime] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         not_null_required (datetime.datetime):
@@ -135,7 +135,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -46,21 +46,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -83,7 +81,8 @@ def sync_detailed(
         cookie_param (Union[Unset, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -104,7 +103,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -126,7 +125,8 @@ async def asyncio_detailed(
         cookie_param (Union[Unset, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -145,4 +145,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -46,7 +46,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -46,7 +46,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -55,7 +55,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -72,7 +72,7 @@ def sync_detailed(
     integer_param: Union[Unset, None, int] = 0,
     header_param: Union[Unset, str] = UNSET,
     cookie_param: Union[Unset, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """Test different types of parameter references
 
     Args:
@@ -87,7 +87,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -115,7 +115,7 @@ async def asyncio_detailed(
     integer_param: Union[Unset, None, int] = 0,
     header_param: Union[Unset, str] = UNSET,
     cookie_param: Union[Unset, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """Test different types of parameter references
 
     Args:
@@ -130,7 +130,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -60,7 +60,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -35,21 +35,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -65,7 +63,8 @@ def sync_detailed(
         param_query (Union[Unset, None, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -83,7 +82,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -98,7 +97,8 @@ async def asyncio_detailed(
         param_query (Union[Unset, None, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -114,4 +114,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -35,7 +35,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -44,7 +44,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,7 +58,7 @@ def sync_detailed(
     *,
     client: Client,
     param_query: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param_path (str):
@@ -69,7 +69,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -91,7 +91,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     param_query: Union[Unset, None, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param_path (str):
@@ -102,7 +102,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -35,7 +35,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -35,7 +35,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -44,7 +44,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,7 +58,7 @@ def sync_detailed(
     *,
     client: Client,
     param_query: str = "overridden_in_GET",
-) -> Response[Any]:
+) -> Response[None]:
     """Test that if you have an overriding property from `PathItem` in `Operation`, it produces valid code
 
     Args:
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     param_query: str = "overridden_in_GET",
-) -> Response[Any]:
+) -> Response[None]:
     """Test that if you have an overriding property from `PathItem` in `Operation`, it produces valid code
 
     Args:
@@ -106,7 +106,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -35,21 +35,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -67,7 +65,8 @@ def sync_detailed(
             'overridden_in_GET'. Example: an example string.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -85,7 +84,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -102,7 +101,8 @@ async def asyncio_detailed(
             'overridden_in_GET'. Example: an example string.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -118,4 +118,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -35,7 +35,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -43,21 +43,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -77,7 +75,8 @@ def sync_detailed(
         param_cookie (Union[Unset, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -97,7 +96,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -116,7 +115,8 @@ async def asyncio_detailed(
         param_cookie (Union[Unset, str]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -134,4 +134,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -43,7 +43,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,7 +68,7 @@ def sync_detailed(
     param_query: Union[Unset, None, str] = UNSET,
     param_header: Union[Unset, str] = UNSET,
     param_cookie: Union[Unset, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param_path (str):
@@ -81,7 +81,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -107,7 +107,7 @@ async def asyncio_detailed(
     param_query: Union[Unset, None, str] = UNSET,
     param_header: Union[Unset, str] = UNSET,
     param_cookie: Union[Unset, str] = UNSET,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param_path (str):
@@ -120,7 +120,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -57,7 +57,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -43,7 +43,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -47,7 +47,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -33,21 +33,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -67,7 +65,8 @@ def sync_detailed(
         param3 (int):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -87,7 +86,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -106,7 +105,8 @@ async def asyncio_detailed(
         param3 (int):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,4 +124,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -42,7 +42,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,7 +58,7 @@ def sync_detailed(
     param3: int,
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param4 (str):
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -97,7 +97,7 @@ async def asyncio_detailed(
     param3: int,
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         param4 (str):
@@ -110,7 +110,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Optional[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
     if response.status_code == HTTPStatus.OK:
         response_200 = PostResponsesUnionsSimpleBeforeComplexResponse200.from_dict(response.json())
 
@@ -45,7 +45,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,7 +57,7 @@ def _build_response(
 def sync_detailed(
     *,
     client: Client,
-) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
     """Regression test for #603
 
     Raises:
@@ -65,7 +65,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PostResponsesUnionsSimpleBeforeComplexResponse200]
+        Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]
     """
 
     kwargs = _get_kwargs(
@@ -83,7 +83,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
     Raises:
@@ -91,7 +91,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PostResponsesUnionsSimpleBeforeComplexResponse200
+        Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]
     """
 
     return sync_detailed(
@@ -102,7 +102,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
     """Regression test for #603
 
     Raises:
@@ -110,7 +110,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[PostResponsesUnionsSimpleBeforeComplexResponse200]
+        Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]
     """
 
     kwargs = _get_kwargs(
@@ -126,7 +126,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
     Raises:
@@ -134,7 +134,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        PostResponsesUnionsSimpleBeforeComplexResponse200
+        Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -30,42 +30,37 @@ def _get_kwargs(
     }
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
+def _parse_response(*, response: httpx.Response) -> PostResponsesUnionsSimpleBeforeComplexResponse200:
     if response.status_code == HTTPStatus.OK:
         response_200 = PostResponsesUnionsSimpleBeforeComplexResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(
-    *, client: Client, response: httpx.Response
-) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
+def _build_response(*, response: httpx.Response) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
+) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]
+        Response[PostResponsesUnionsSimpleBeforeComplexResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -77,21 +72,22 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> PostResponsesUnionsSimpleBeforeComplexResponse200:
     """Regression test for #603
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]
+        PostResponsesUnionsSimpleBeforeComplexResponse200
     """
 
     return sync_detailed(
@@ -102,15 +98,16 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]:
+) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]]
+        Response[PostResponsesUnionsSimpleBeforeComplexResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -120,21 +117,22 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]:
+) -> PostResponsesUnionsSimpleBeforeComplexResponse200:
     """Regression test for #603
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[None, PostResponsesUnionsSimpleBeforeComplexResponse200]
+        PostResponsesUnionsSimpleBeforeComplexResponse200
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -27,21 +27,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -51,7 +49,8 @@ def sync_detailed(
 ) -> Response[None]:
     """
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -67,7 +66,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -76,7 +75,8 @@ async def asyncio_detailed(
 ) -> Response[None]:
     """
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -90,4 +90,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -41,7 +41,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -36,7 +36,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -48,14 +48,14 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Any
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -73,14 +73,14 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     json_body: AModel,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Path with callback
 
      Try sending a request related to a callback
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: AModel,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Path with callback
 
      Try sending a request related to a callback
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -35,7 +35,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -6,7 +6,6 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.a_model import AModel
-from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
@@ -33,26 +32,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -69,7 +62,8 @@ def sync_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -86,7 +80,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -102,7 +96,8 @@ def sync(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,7 +123,8 @@ async def asyncio_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,7 +139,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -159,7 +155,8 @@ async def asyncio(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     json_body: AModel,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: AModel,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Path with callback
 
      Try sending a request related to a callback
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 from dateutil.parser import isoparse
@@ -102,7 +102,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -1,6 +1,6 @@
 import datetime
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 import httpx
 from dateutil.parser import isoparse
@@ -100,7 +100,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -114,7 +114,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -137,7 +137,7 @@ def sync_detailed(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Defaults
 
     Args:
@@ -158,7 +158,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -198,7 +198,7 @@ def sync(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Defaults
 
     Args:
@@ -219,7 +219,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -252,7 +252,7 @@ async def asyncio_detailed(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Defaults
 
     Args:
@@ -273,7 +273,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -311,7 +311,7 @@ async def asyncio(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Defaults
 
     Args:
@@ -332,7 +332,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/defaults_tests_defaults_post.py
@@ -100,7 +100,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -114,7 +114,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -137,7 +137,7 @@ def sync_detailed(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Defaults
 
     Args:
@@ -158,7 +158,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -198,7 +198,7 @@ def sync(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Defaults
 
     Args:
@@ -219,7 +219,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -252,7 +252,7 @@ async def asyncio_detailed(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Defaults
 
     Args:
@@ -273,7 +273,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -311,7 +311,7 @@ async def asyncio(
     enum_prop: AnEnum,
     model_prop: "ModelWithUnionProperty",
     required_model_prop: "ModelWithUnionProperty",
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Defaults
 
     Args:
@@ -332,7 +332,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -36,7 +36,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -48,7 +48,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Any
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     r""" Test description with \
 
      Test description with \
@@ -58,7 +58,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
      """
 
     kwargs = _get_kwargs(
@@ -76,7 +76,7 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[None]:
     r""" Test description with \
 
      Test description with \
@@ -86,7 +86,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
      """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -41,7 +41,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -27,21 +27,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -54,7 +52,8 @@ def sync_detailed(
      Test description with \
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -70,7 +69,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -82,7 +81,8 @@ async def asyncio_detailed(
      Test description with \
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -96,4 +96,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Union, cast
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List[bool]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[bool], None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[bool], response.json())
 
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[List[bool]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[bool], None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[List[bool]]:
+) -> Response[Union[List[bool], None]]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[bool]]
+        Response[Union[List[bool], None]]
     """
 
     kwargs = _get_kwargs(
@@ -78,7 +78,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[List[bool]]:
+) -> Union[List[bool], None]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
@@ -88,7 +88,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[bool]
+        Union[List[bool], None]
     """
 
     return sync_detailed(
@@ -99,7 +99,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[List[bool]]:
+) -> Response[Union[List[bool], None]]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
@@ -109,7 +109,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[bool]]
+        Response[Union[List[bool], None]]
     """
 
     kwargs = _get_kwargs(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[List[bool]]:
+) -> Union[List[bool], None]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
@@ -135,7 +135,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[bool]
+        Union[List[bool], None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, cast
 
 import httpx
 
@@ -27,40 +27,39 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[bool], None]:
+def _parse_response(*, response: httpx.Response) -> List[bool]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[bool], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[bool], None]]:
+def _build_response(*, response: httpx.Response) -> Response[List[bool]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[List[bool], None]]:
+) -> Response[List[bool]]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[bool], None]]
+        Response[List[bool]]
     """
 
     kwargs = _get_kwargs(
@@ -72,23 +71,24 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[List[bool], None]:
+) -> List[bool]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[bool], None]
+        List[bool]
     """
 
     return sync_detailed(
@@ -99,17 +99,18 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[List[bool], None]]:
+) -> Response[List[bool]]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[bool], None]]
+        Response[List[bool]]
     """
 
     kwargs = _get_kwargs(
@@ -119,23 +120,24 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[List[bool], None]:
+) -> List[bool]:
     """Get Basic List Of Booleans
 
      Get a list of booleans
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[bool], None]
+        List[bool]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Union, cast
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List[float]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[float], None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[float], response.json())
 
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[List[float]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[float], None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[List[float]]:
+) -> Response[Union[List[float], None]]:
     """Get Basic List Of Floats
 
      Get a list of floats
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[float]]
+        Response[Union[List[float], None]]
     """
 
     kwargs = _get_kwargs(
@@ -78,7 +78,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[List[float]]:
+) -> Union[List[float], None]:
     """Get Basic List Of Floats
 
      Get a list of floats
@@ -88,7 +88,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[float]
+        Union[List[float], None]
     """
 
     return sync_detailed(
@@ -99,7 +99,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[List[float]]:
+) -> Response[Union[List[float], None]]:
     """Get Basic List Of Floats
 
      Get a list of floats
@@ -109,7 +109,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[float]]
+        Response[Union[List[float], None]]
     """
 
     kwargs = _get_kwargs(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[List[float]]:
+) -> Union[List[float], None]:
     """Get Basic List Of Floats
 
      Get a list of floats
@@ -135,7 +135,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[float]
+        Union[List[float], None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, cast
 
 import httpx
 
@@ -27,40 +27,39 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[float], None]:
+def _parse_response(*, response: httpx.Response) -> List[float]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[float], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[float], None]]:
+def _build_response(*, response: httpx.Response) -> Response[List[float]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[List[float], None]]:
+) -> Response[List[float]]:
     """Get Basic List Of Floats
 
      Get a list of floats
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[float], None]]
+        Response[List[float]]
     """
 
     kwargs = _get_kwargs(
@@ -72,23 +71,24 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[List[float], None]:
+) -> List[float]:
     """Get Basic List Of Floats
 
      Get a list of floats
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[float], None]
+        List[float]
     """
 
     return sync_detailed(
@@ -99,17 +99,18 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[List[float], None]]:
+) -> Response[List[float]]:
     """Get Basic List Of Floats
 
      Get a list of floats
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[float], None]]
+        Response[List[float]]
     """
 
     kwargs = _get_kwargs(
@@ -119,23 +120,24 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[List[float], None]:
+) -> List[float]:
     """Get Basic List Of Floats
 
      Get a list of floats
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[float], None]
+        List[float]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, cast
 
 import httpx
 
@@ -27,40 +27,39 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[int], None]:
+def _parse_response(*, response: httpx.Response) -> List[int]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[int], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[int], None]]:
+def _build_response(*, response: httpx.Response) -> Response[List[int]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[List[int], None]]:
+) -> Response[List[int]]:
     """Get Basic List Of Integers
 
      Get a list of integers
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[int], None]]
+        Response[List[int]]
     """
 
     kwargs = _get_kwargs(
@@ -72,23 +71,24 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[List[int], None]:
+) -> List[int]:
     """Get Basic List Of Integers
 
      Get a list of integers
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[int], None]
+        List[int]
     """
 
     return sync_detailed(
@@ -99,17 +99,18 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[List[int], None]]:
+) -> Response[List[int]]:
     """Get Basic List Of Integers
 
      Get a list of integers
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[int], None]]
+        Response[List[int]]
     """
 
     kwargs = _get_kwargs(
@@ -119,23 +120,24 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[List[int], None]:
+) -> List[int]:
     """Get Basic List Of Integers
 
      Get a list of integers
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[int], None]
+        List[int]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Union, cast
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List[int]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[int], None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[int], response.json())
 
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[List[int]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[int], None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[List[int]]:
+) -> Response[Union[List[int], None]]:
     """Get Basic List Of Integers
 
      Get a list of integers
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[int]]
+        Response[Union[List[int], None]]
     """
 
     kwargs = _get_kwargs(
@@ -78,7 +78,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[List[int]]:
+) -> Union[List[int], None]:
     """Get Basic List Of Integers
 
      Get a list of integers
@@ -88,7 +88,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[int]
+        Union[List[int], None]
     """
 
     return sync_detailed(
@@ -99,7 +99,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[List[int]]:
+) -> Response[Union[List[int], None]]:
     """Get Basic List Of Integers
 
      Get a list of integers
@@ -109,7 +109,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[int]]
+        Response[Union[List[int], None]]
     """
 
     kwargs = _get_kwargs(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[List[int]]:
+) -> Union[List[int], None]:
     """Get Basic List Of Integers
 
      Get a list of integers
@@ -135,7 +135,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[int]
+        Union[List[int], None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, cast
 
 import httpx
 
@@ -27,40 +27,39 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[str], None]:
+def _parse_response(*, response: httpx.Response) -> List[str]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[str], response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[str], None]]:
+def _build_response(*, response: httpx.Response) -> Response[List[str]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[List[str], None]]:
+) -> Response[List[str]]:
     """Get Basic List Of Strings
 
      Get a list of strings
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[str], None]]
+        Response[List[str]]
     """
 
     kwargs = _get_kwargs(
@@ -72,23 +71,24 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[List[str], None]:
+) -> List[str]:
     """Get Basic List Of Strings
 
      Get a list of strings
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[str], None]
+        List[str]
     """
 
     return sync_detailed(
@@ -99,17 +99,18 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[List[str], None]]:
+) -> Response[List[str]]:
     """Get Basic List Of Strings
 
      Get a list of strings
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[List[str], None]]
+        Response[List[str]]
     """
 
     kwargs = _get_kwargs(
@@ -119,23 +120,24 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[List[str], None]:
+) -> List[str]:
     """Get Basic List Of Strings
 
      Get a list of strings
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[List[str], None]
+        List[str]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Union, cast
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List[str]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[List[str], None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(List[str], response.json())
 
@@ -38,7 +38,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Lis
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[List[str]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[List[str], None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -50,7 +50,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Lis
 def sync_detailed(
     *,
     client: Client,
-) -> Response[List[str]]:
+) -> Response[Union[List[str], None]]:
     """Get Basic List Of Strings
 
      Get a list of strings
@@ -60,7 +60,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[str]]
+        Response[Union[List[str], None]]
     """
 
     kwargs = _get_kwargs(
@@ -78,7 +78,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[List[str]]:
+) -> Union[List[str], None]:
     """Get Basic List Of Strings
 
      Get a list of strings
@@ -88,7 +88,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[str]
+        Union[List[str], None]
     """
 
     return sync_detailed(
@@ -99,7 +99,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[List[str]]:
+) -> Response[Union[List[str], None]]:
     """Get Basic List Of Strings
 
      Get a list of strings
@@ -109,7 +109,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[List[str]]
+        Response[Union[List[str], None]]
     """
 
     kwargs = _get_kwargs(
@@ -125,7 +125,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[List[str]]:
+) -> Union[List[str], None]:
     """Get Basic List Of Strings
 
      Get a list of strings
@@ -135,7 +135,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        List[str]
+        Union[List[str], None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -9,7 +9,6 @@ from ...client import Client
 from ...models.a_model import AModel
 from ...models.an_enum import AnEnum
 from ...models.an_enum_with_null import AnEnumWithNull
-from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response
 
 
@@ -71,7 +70,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[HTTPValidationError, List["AModel"], None]:
+def _parse_response(*, response: httpx.Response) -> List["AModel"]:
     if response.status_code == HTTPStatus.OK:
         response_200 = []
         _response_200 = response.json()
@@ -81,28 +80,16 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[HTTPVa
             response_200.append(response_200_item)
 
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if response.status_code == HTTPStatus.LOCKED:
-        response_423 = HTTPValidationError.from_dict(response.json())
-
-        return response_423
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(
-    *, client: Client, response: httpx.Response
-) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
+def _build_response(*, response: httpx.Response) -> Response[List["AModel"]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -113,7 +100,7 @@ def sync_detailed(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
+) -> Response[List["AModel"]]:
     """Get List
 
      Get a list of things
@@ -125,11 +112,12 @@ def sync_detailed(
         some_date (Union[datetime.date, datetime.datetime]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, List['AModel'], None]]
+        Response[List['AModel']]
     """
 
     kwargs = _get_kwargs(
@@ -145,7 +133,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -155,7 +143,7 @@ def sync(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Union[HTTPValidationError, List["AModel"], None]:
+) -> List["AModel"]:
     """Get List
 
      Get a list of things
@@ -167,11 +155,12 @@ def sync(
         some_date (Union[datetime.date, datetime.datetime]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, List['AModel'], None]
+        List['AModel']
     """
 
     return sync_detailed(
@@ -190,7 +179,7 @@ async def asyncio_detailed(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
+) -> Response[List["AModel"]]:
     """Get List
 
      Get a list of things
@@ -202,11 +191,12 @@ async def asyncio_detailed(
         some_date (Union[datetime.date, datetime.datetime]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, List['AModel'], None]]
+        Response[List['AModel']]
     """
 
     kwargs = _get_kwargs(
@@ -220,7 +210,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -230,7 +220,7 @@ async def asyncio(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Union[HTTPValidationError, List["AModel"], None]:
+) -> List["AModel"]:
     """Get List
 
      Get a list of things
@@ -242,11 +232,12 @@ async def asyncio(
         some_date (Union[datetime.date, datetime.datetime]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, List['AModel'], None]
+        List['AModel']
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -71,9 +71,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(
-    *, client: Client, response: httpx.Response
-) -> Optional[Union[HTTPValidationError, List["AModel"]]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[HTTPValidationError, List["AModel"], None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = []
         _response_200 = response.json()
@@ -99,7 +97,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[HTTPValidationError, List["AModel"]]]:
+) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -115,7 +113,7 @@ def sync_detailed(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[HTTPValidationError, List["AModel"]]]:
+) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
     """Get List
 
      Get a list of things
@@ -131,7 +129,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, List['AModel']]]
+        Response[Union[HTTPValidationError, List['AModel'], None]]
     """
 
     kwargs = _get_kwargs(
@@ -157,7 +155,7 @@ def sync(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Optional[Union[HTTPValidationError, List["AModel"]]]:
+) -> Union[HTTPValidationError, List["AModel"], None]:
     """Get List
 
      Get a list of things
@@ -173,7 +171,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, List['AModel']]
+        Union[HTTPValidationError, List['AModel'], None]
     """
 
     return sync_detailed(
@@ -192,7 +190,7 @@ async def asyncio_detailed(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Response[Union[HTTPValidationError, List["AModel"]]]:
+) -> Response[Union[HTTPValidationError, List["AModel"], None]]:
     """Get List
 
      Get a list of things
@@ -208,7 +206,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, List['AModel']]]
+        Response[Union[HTTPValidationError, List['AModel'], None]]
     """
 
     kwargs = _get_kwargs(
@@ -232,7 +230,7 @@ async def asyncio(
     an_enum_value_with_null: List[Optional[AnEnumWithNull]],
     an_enum_value_with_only_null: List[None],
     some_date: Union[datetime.date, datetime.datetime],
-) -> Optional[Union[HTTPValidationError, List["AModel"]]]:
+) -> Union[HTTPValidationError, List["AModel"], None]:
     """Get List
 
      Get a list of things
@@ -248,7 +246,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, List['AModel']]
+        Union[HTTPValidationError, List['AModel'], None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -38,7 +38,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Int Enum
 
     Args:
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -96,7 +96,7 @@ def sync(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Int Enum
 
     Args:
@@ -107,7 +107,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -120,7 +120,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Int Enum
 
     Args:
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -149,7 +149,7 @@ async def asyncio(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Int Enum
 
     Args:
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -38,7 +38,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -52,7 +52,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,7 +65,7 @@ def sync_detailed(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Int Enum
 
     Args:
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -96,7 +96,7 @@ def sync(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Int Enum
 
     Args:
@@ -107,7 +107,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -120,7 +120,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Int Enum
 
     Args:
@@ -131,7 +131,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -149,7 +149,7 @@ async def asyncio(
     *,
     client: Client,
     int_enum: AnIntEnum,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Int Enum
 
     Args:
@@ -160,7 +160,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
@@ -6,7 +6,6 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.an_int_enum import AnIntEnum
-from ...models.http_validation_error import HTTPValidationError
 from ...types import UNSET, Response
 
 
@@ -38,26 +37,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -72,7 +65,8 @@ def sync_detailed(
         int_enum (AnIntEnum): An enumeration.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -89,7 +83,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -103,7 +97,8 @@ def sync(
         int_enum (AnIntEnum): An enumeration.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -127,7 +122,8 @@ async def asyncio_detailed(
         int_enum (AnIntEnum): An enumeration.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -142,7 +138,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -156,7 +152,8 @@ async def asyncio(
         int_enum (AnIntEnum): An enumeration.
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/int_enum_tests_int_enum_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -40,7 +40,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -35,7 +35,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -6,7 +6,6 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.a_model import AModel
-from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
@@ -33,26 +32,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -69,7 +62,8 @@ def sync_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -86,7 +80,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -102,7 +96,8 @@ def sync(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,7 +123,8 @@ async def asyncio_detailed(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,7 +139,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -159,7 +155,8 @@ async def asyncio(
         json_body (AModel): A Model for testing all the ways custom objects can be used
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Json Body
 
      Try sending a JSON body
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     json_body: AModel,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Json Body
 
      Try sending a JSON body
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Json Body
 
      Try sending a JSON body
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: AModel,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Json Body
 
      Try sending a JSON body
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Json Body
 
      Try sending a JSON body
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     json_body: AModel,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Json Body
 
      Try sending a JSON body
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: AModel,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Json Body
 
      Try sending a JSON body
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: AModel,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Json Body
 
      Try sending a JSON body
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -37,7 +37,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Any
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """No Response
 
     Raises:
@@ -57,7 +57,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """No Response
 
     Raises:
@@ -83,7 +83,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return sync_detailed(
@@ -94,7 +94,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """No Response
 
     Raises:
@@ -102,7 +102,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """No Response
 
     Raises:
@@ -126,7 +126,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import httpx
 
@@ -29,7 +29,8 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        return None
+        response_200 = cast(Any, response.json())
+        return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -71,6 +72,25 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
+def sync(
+    *,
+    client: Client,
+) -> Optional[Any]:
+    """No Response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
 async def asyncio_detailed(
     *,
     client: Client,
@@ -93,3 +113,24 @@ async def asyncio_detailed(
         response = await _client.request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> Optional[Any]:
+    """No Response
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -29,7 +29,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -37,7 +37,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, N
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Uni
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """No Response
 
     Raises:
@@ -57,7 +57,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Any, None]:
+) -> Any:
     """No Response
 
     Raises:
@@ -83,7 +83,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return sync_detailed(
@@ -94,7 +94,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """No Response
 
     Raises:
@@ -102,7 +102,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Any, None]:
+) -> Any:
     """No Response
 
     Raises:
@@ -126,7 +126,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -27,22 +27,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -53,7 +51,8 @@ def sync_detailed(
     """No Response
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -69,7 +68,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -79,7 +78,8 @@ def sync(
     """No Response
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -98,7 +98,8 @@ async def asyncio_detailed(
     """No Response
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,7 +113,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -122,7 +123,8 @@ async def asyncio(
     """No Response
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -28,7 +28,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[File]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[File, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = File(payload=BytesIO(response.content))
 
@@ -39,7 +39,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Fil
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[File]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[File, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -51,7 +51,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Fil
 def sync_detailed(
     *,
     client: Client,
-) -> Response[File]:
+) -> Response[Union[File, None]]:
     """Octet Stream
 
     Raises:
@@ -59,7 +59,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[File]
+        Response[Union[File, None]]
     """
 
     kwargs = _get_kwargs(
@@ -77,7 +77,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[File]:
+) -> Union[File, None]:
     """Octet Stream
 
     Raises:
@@ -85,7 +85,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        File
+        Union[File, None]
     """
 
     return sync_detailed(
@@ -96,7 +96,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[File]:
+) -> Response[Union[File, None]]:
     """Octet Stream
 
     Raises:
@@ -104,7 +104,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[File]
+        Response[Union[File, None]]
     """
 
     kwargs = _get_kwargs(
@@ -120,7 +120,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[File]:
+) -> Union[File, None]:
     """Octet Stream
 
     Raises:
@@ -128,7 +128,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        File
+        Union[File, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from io import BytesIO
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -28,38 +28,37 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[File, None]:
+def _parse_response(*, response: httpx.Response) -> File:
     if response.status_code == HTTPStatus.OK:
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[File, None]]:
+def _build_response(*, response: httpx.Response) -> Response[File]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[File, None]]:
+) -> Response[File]:
     """Octet Stream
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[File, None]]
+        Response[File]
     """
 
     kwargs = _get_kwargs(
@@ -71,21 +70,22 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
-) -> Union[File, None]:
+) -> File:
     """Octet Stream
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[File, None]
+        File
     """
 
     return sync_detailed(
@@ -96,15 +96,16 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[File, None]]:
+) -> Response[File]:
     """Octet Stream
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[File, None]]
+        Response[File]
     """
 
     kwargs = _get_kwargs(
@@ -114,21 +115,22 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
-) -> Union[File, None]:
+) -> File:
     """Octet Stream
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[File, None]
+        File
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +53,7 @@ def sync_detailed(
     *,
     client: Client,
     form_data: AFormData,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Post form data
 
      Post form data
@@ -63,7 +63,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -83,7 +83,7 @@ def sync(
     *,
     client: Client,
     form_data: AFormData,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Post form data
 
      Post form data
@@ -93,7 +93,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return sync_detailed(
@@ -106,7 +106,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     form_data: AFormData,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Post form data
 
      Post form data
@@ -116,7 +116,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +134,7 @@ async def asyncio(
     *,
     client: Client,
     form_data: AFormData,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Post form data
 
      Post form data
@@ -144,7 +144,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -30,22 +30,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -59,7 +57,8 @@ def sync_detailed(
      Post form data
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -76,7 +75,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -89,7 +88,8 @@ def sync(
      Post form data
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,7 +112,8 @@ async def asyncio_detailed(
      Post form data
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -127,7 +128,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -140,7 +141,8 @@ async def asyncio(
      Post form data
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import httpx
 
@@ -32,7 +32,8 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        return None
+        response_200 = cast(Any, response.json())
+        return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -78,6 +79,29 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
+def sync(
+    *,
+    client: Client,
+    form_data: AFormData,
+) -> Optional[Any]:
+    """Post form data
+
+     Post form data
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return sync_detailed(
+        client=client,
+        form_data=form_data,
+    ).parsed
+
+
 async def asyncio_detailed(
     *,
     client: Client,
@@ -104,3 +128,28 @@ async def asyncio_detailed(
         response = await _client.request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    form_data: AFormData,
+) -> Optional[Any]:
+    """Post form data
+
+     Post form data
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            form_data=form_data,
+        )
+    ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, N
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +53,7 @@ def sync_detailed(
     *,
     client: Client,
     form_data: AFormData,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Post form data
 
      Post form data
@@ -63,7 +63,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -83,7 +83,7 @@ def sync(
     *,
     client: Client,
     form_data: AFormData,
-) -> Union[Any, None]:
+) -> Any:
     """Post form data
 
      Post form data
@@ -93,7 +93,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return sync_detailed(
@@ -106,7 +106,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     form_data: AFormData,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Post form data
 
      Post form data
@@ -116,7 +116,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +134,7 @@ async def asyncio(
     *,
     client: Client,
     form_data: AFormData,
-) -> Union[Any, None]:
+) -> Any:
     """Post form data
 
      Post form data
@@ -144,7 +144,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +53,7 @@ def sync_detailed(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -63,7 +63,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -83,7 +83,7 @@ def sync(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -93,7 +93,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return sync_detailed(
@@ -106,7 +106,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -116,7 +116,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +134,7 @@ async def asyncio(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -144,7 +144,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -32,7 +32,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import httpx
 
@@ -32,7 +32,8 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        return None
+        response_200 = cast(Any, response.json())
+        return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -78,6 +79,29 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
+def sync(
+    *,
+    client: Client,
+    form_data: PostFormDataInlineData,
+) -> Optional[Any]:
+    """Post form data (inline schema)
+
+     Post form data (inline schema)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return sync_detailed(
+        client=client,
+        form_data=form_data,
+    ).parsed
+
+
 async def asyncio_detailed(
     *,
     client: Client,
@@ -104,3 +128,28 @@ async def asyncio_detailed(
         response = await _client.request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    form_data: PostFormDataInlineData,
+) -> Optional[Any]:
+    """Post form data (inline schema)
+
+     Post form data (inline schema)
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            form_data=form_data,
+        )
+    ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -30,22 +30,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -59,7 +57,8 @@ def sync_detailed(
      Post form data (inline schema)
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -76,7 +75,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -89,7 +88,8 @@ def sync(
      Post form data (inline schema)
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,7 +112,8 @@ async def asyncio_detailed(
      Post form data (inline schema)
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -127,7 +128,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -140,7 +141,8 @@ async def asyncio(
      Post form data (inline schema)
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -40,7 +40,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, N
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -53,7 +53,7 @@ def sync_detailed(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -63,7 +63,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -83,7 +83,7 @@ def sync(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Union[Any, None]:
+) -> Any:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -93,7 +93,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return sync_detailed(
@@ -106,7 +106,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -116,7 +116,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -134,7 +134,7 @@ async def asyncio(
     *,
     client: Client,
     form_data: PostFormDataInlineData,
-) -> Union[Any, None]:
+) -> Any:
     """Post form data (inline schema)
 
      Post form data (inline schema)
@@ -144,7 +144,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Union, cast
 
 import httpx
 
@@ -32,7 +32,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[HTTPValidationError, str]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[HTTPValidationError, None, str]:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(str, response.json())
         return response_200
@@ -46,7 +46,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[HTTPValidationError, str]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[HTTPValidationError, None, str]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -59,7 +59,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: str,
-) -> Response[Union[HTTPValidationError, str]]:
+) -> Response[Union[HTTPValidationError, None, str]]:
     """Json Body Which is String
 
     Args:
@@ -70,7 +70,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, str]]
+        Response[Union[HTTPValidationError, None, str]]
     """
 
     kwargs = _get_kwargs(
@@ -90,7 +90,7 @@ def sync(
     *,
     client: Client,
     json_body: str,
-) -> Optional[Union[HTTPValidationError, str]]:
+) -> Union[HTTPValidationError, None, str]:
     """Json Body Which is String
 
     Args:
@@ -101,7 +101,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, str]
+        Union[HTTPValidationError, None, str]
     """
 
     return sync_detailed(
@@ -114,7 +114,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: str,
-) -> Response[Union[HTTPValidationError, str]]:
+) -> Response[Union[HTTPValidationError, None, str]]:
     """Json Body Which is String
 
     Args:
@@ -125,7 +125,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, str]]
+        Response[Union[HTTPValidationError, None, str]]
     """
 
     kwargs = _get_kwargs(
@@ -143,7 +143,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: str,
-) -> Optional[Union[HTTPValidationError, str]]:
+) -> Union[HTTPValidationError, None, str]:
     """Json Body Which is String
 
     Args:
@@ -154,7 +154,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, str]
+        Union[HTTPValidationError, None, str]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
@@ -1,11 +1,10 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union, cast
+from typing import Any, Dict, cast
 
 import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
@@ -32,26 +31,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[HTTPValidationError, None, str]:
+def _parse_response(*, response: httpx.Response) -> str:
     if response.status_code == HTTPStatus.OK:
         response_200 = cast(str, response.json())
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[HTTPValidationError, None, str]]:
+def _build_response(*, response: httpx.Response) -> Response[str]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -59,18 +52,19 @@ def sync_detailed(
     *,
     client: Client,
     json_body: str,
-) -> Response[Union[HTTPValidationError, None, str]]:
+) -> Response[str]:
     """Json Body Which is String
 
     Args:
         json_body (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, None, str]]
+        Response[str]
     """
 
     kwargs = _get_kwargs(
@@ -83,25 +77,26 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
     json_body: str,
-) -> Union[HTTPValidationError, None, str]:
+) -> str:
     """Json Body Which is String
 
     Args:
         json_body (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, None, str]
+        str
     """
 
     return sync_detailed(
@@ -114,18 +109,19 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: str,
-) -> Response[Union[HTTPValidationError, None, str]]:
+) -> Response[str]:
     """Json Body Which is String
 
     Args:
         json_body (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[HTTPValidationError, None, str]]
+        Response[str]
     """
 
     kwargs = _get_kwargs(
@@ -136,25 +132,26 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
     json_body: str,
-) -> Union[HTTPValidationError, None, str]:
+) -> str:
     """Json Body Which is String
 
     Args:
         json_body (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[HTTPValidationError, None, str]
+        str
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[TestInlineObjectsResponse200]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[None, TestInlineObjectsResponse200]:
     if response.status_code == HTTPStatus.OK:
         response_200 = TestInlineObjectsResponse200.from_dict(response.json())
 
@@ -44,7 +44,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Tes
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[TestInlineObjectsResponse200]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[None, TestInlineObjectsResponse200]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -57,7 +57,7 @@ def sync_detailed(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Response[TestInlineObjectsResponse200]:
+) -> Response[Union[None, TestInlineObjectsResponse200]]:
     """Test Inline Objects
 
     Args:
@@ -68,7 +68,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[TestInlineObjectsResponse200]
+        Response[Union[None, TestInlineObjectsResponse200]]
     """
 
     kwargs = _get_kwargs(
@@ -88,7 +88,7 @@ def sync(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Optional[TestInlineObjectsResponse200]:
+) -> Union[None, TestInlineObjectsResponse200]:
     """Test Inline Objects
 
     Args:
@@ -99,7 +99,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        TestInlineObjectsResponse200
+        Union[None, TestInlineObjectsResponse200]
     """
 
     return sync_detailed(
@@ -112,7 +112,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Response[TestInlineObjectsResponse200]:
+) -> Response[Union[None, TestInlineObjectsResponse200]]:
     """Test Inline Objects
 
     Args:
@@ -123,7 +123,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[TestInlineObjectsResponse200]
+        Response[Union[None, TestInlineObjectsResponse200]]
     """
 
     kwargs = _get_kwargs(
@@ -141,7 +141,7 @@ async def asyncio(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Optional[TestInlineObjectsResponse200]:
+) -> Union[None, TestInlineObjectsResponse200]:
     """Test Inline Objects
 
     Args:
@@ -152,7 +152,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        TestInlineObjectsResponse200
+        Union[None, TestInlineObjectsResponse200]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -33,23 +33,21 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[None, TestInlineObjectsResponse200]:
+def _parse_response(*, response: httpx.Response) -> TestInlineObjectsResponse200:
     if response.status_code == HTTPStatus.OK:
         response_200 = TestInlineObjectsResponse200.from_dict(response.json())
 
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[None, TestInlineObjectsResponse200]]:
+def _build_response(*, response: httpx.Response) -> Response[TestInlineObjectsResponse200]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -57,18 +55,19 @@ def sync_detailed(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Response[Union[None, TestInlineObjectsResponse200]]:
+) -> Response[TestInlineObjectsResponse200]:
     """Test Inline Objects
 
     Args:
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[None, TestInlineObjectsResponse200]]
+        Response[TestInlineObjectsResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -81,25 +80,26 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Union[None, TestInlineObjectsResponse200]:
+) -> TestInlineObjectsResponse200:
     """Test Inline Objects
 
     Args:
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[None, TestInlineObjectsResponse200]
+        TestInlineObjectsResponse200
     """
 
     return sync_detailed(
@@ -112,18 +112,19 @@ async def asyncio_detailed(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Response[Union[None, TestInlineObjectsResponse200]]:
+) -> Response[TestInlineObjectsResponse200]:
     """Test Inline Objects
 
     Args:
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[None, TestInlineObjectsResponse200]]
+        Response[TestInlineObjectsResponse200]
     """
 
     kwargs = _get_kwargs(
@@ -134,25 +135,26 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
     *,
     client: Client,
     json_body: TestInlineObjectsJsonBody,
-) -> Union[None, TestInlineObjectsResponse200]:
+) -> TestInlineObjectsResponse200:
     """Test Inline Objects
 
     Args:
         json_body (TestInlineObjectsJsonBody):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[None, TestInlineObjectsResponse200]
+        TestInlineObjectsResponse200
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, None]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -89,7 +89,7 @@ def sync(
     *,
     client: Client,
     my_token: str,
-) -> Optional[Union[Any, None]]:
+) -> Union[Any, None]:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Union[Any, None]
     """
 
     return sync_detailed(
@@ -146,7 +146,7 @@ async def asyncio(
     *,
     client: Client,
     my_token: str,
-) -> Optional[Union[Any, None]]:
+) -> Union[Any, None]:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -159,7 +159,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Union[Any, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -30,7 +30,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, N
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +56,7 @@ def sync_detailed(
     *,
     client: Client,
     my_token: str,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -69,7 +69,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -89,7 +89,7 @@ def sync(
     *,
     client: Client,
     my_token: str,
-) -> Union[Any, None]:
+) -> Any:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return sync_detailed(
@@ -115,7 +115,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     my_token: str,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -128,7 +128,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -146,7 +146,7 @@ async def asyncio(
     *,
     client: Client,
     my_token: str,
-) -> Union[Any, None]:
+) -> Any:
     """TOKEN_WITH_COOKIE
 
      Test optional cookie parameters
@@ -159,7 +159,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -30,25 +30,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = None
-        return response_401
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -65,7 +60,8 @@ def sync_detailed(
         my_token (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -82,7 +78,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -98,7 +94,8 @@ def sync(
         my_token (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -124,7 +121,8 @@ async def asyncio_detailed(
         my_token (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -139,7 +137,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -155,7 +153,8 @@ async def asyncio(
         my_token (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -32,10 +32,10 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, None]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNAUTHORIZED:
-        response_401 = cast(None, None)
+        response_401 = None
         return response_401
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -27,22 +27,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -53,7 +51,8 @@ def sync_detailed(
     """Unsupported Content
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -69,7 +68,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -79,7 +78,8 @@ def sync(
     """Unsupported Content
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -98,7 +98,8 @@ async def asyncio_detailed(
     """Unsupported Content
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -112,7 +113,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -122,7 +123,8 @@ async def asyncio(
     """Unsupported Content
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import httpx
 
@@ -29,7 +29,8 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        return None
+        response_200 = cast(Any, response.json())
+        return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -71,6 +72,25 @@ def sync_detailed(
     return _build_response(client=client, response=response)
 
 
+def sync(
+    *,
+    client: Client,
+) -> Optional[Any]:
+    """Unsupported Content
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
 async def asyncio_detailed(
     *,
     client: Client,
@@ -93,3 +113,24 @@ async def asyncio_detailed(
         response = await _client.request(**kwargs)
 
     return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> Optional[Any]:
+    """Unsupported Content
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, Optional
 
 import httpx
 
@@ -29,7 +29,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -37,7 +37,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Any
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Unsupported Content
 
     Raises:
@@ -57,7 +57,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Unsupported Content
 
     Raises:
@@ -83,7 +83,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return sync_detailed(
@@ -94,7 +94,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Any]:
+) -> Response[Union[Any, None]]:
     """Unsupported Content
 
     Raises:
@@ -102,7 +102,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[Union[Any, None]]
     """
 
     kwargs = _get_kwargs(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Optional[Any]:
+) -> Union[Any, None]:
     """Unsupported Content
 
     Raises:
@@ -126,7 +126,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Union[Any, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -27,7 +27,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -37,7 +37,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, N
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -49,7 +49,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Uni
 def sync_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Unsupported Content
 
     Raises:
@@ -57,7 +57,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -75,7 +75,7 @@ def sync_detailed(
 def sync(
     *,
     client: Client,
-) -> Union[Any, None]:
+) -> Any:
     """Unsupported Content
 
     Raises:
@@ -83,7 +83,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return sync_detailed(
@@ -94,7 +94,7 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Client,
-) -> Response[Union[Any, None]]:
+) -> Response[Any]:
     """Unsupported Content
 
     Raises:
@@ -102,7 +102,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -118,7 +118,7 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Client,
-) -> Union[Any, None]:
+) -> Any:
     """Unsupported Content
 
     Raises:
@@ -126,7 +126,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union
 
 import httpx
 
@@ -35,7 +35,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Upload File
 
      Upload a file
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Upload File
 
      Upload a file
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Upload File
 
      Upload a file
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Upload File
 
      Upload a file
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -6,7 +6,6 @@ import httpx
 from ... import errors
 from ...client import Client
 from ...models.body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
-from ...models.http_validation_error import HTTPValidationError
 from ...types import Response
 
 
@@ -33,26 +32,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -69,7 +62,8 @@ def sync_detailed(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -86,7 +80,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -102,7 +96,8 @@ def sync(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -128,7 +123,8 @@ async def asyncio_detailed(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -143,7 +139,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -159,7 +155,8 @@ async def asyncio(
         multipart_data (BodyUploadFileTestsUploadPost):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Union
+from typing import Any, Dict
 
 import httpx
 
@@ -33,7 +33,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -47,7 +47,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -60,7 +60,7 @@ def sync_detailed(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Upload File
 
      Upload a file
@@ -73,7 +73,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -93,7 +93,7 @@ def sync(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Upload File
 
      Upload a file
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Upload File
 
      Upload a file
@@ -132,7 +132,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -150,7 +150,7 @@ async def asyncio(
     *,
     client: Client,
     multipart_data: BodyUploadFileTestsUploadPost,
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Upload File
 
      Upload a file
@@ -163,7 +163,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
@@ -38,7 +38,7 @@ def _get_kwargs(
 
 def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Any, response.json())
+        response_200 = response.json()
         return response_200
     if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
         response_422 = HTTPValidationError.from_dict(response.json())

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -5,7 +5,6 @@ import httpx
 
 from ... import errors
 from ...client import Client
-from ...models.http_validation_error import HTTPValidationError
 from ...types import File, Response
 
 
@@ -36,26 +35,20 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Any:
+def _parse_response(*, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
-    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
-        response_422 = HTTPValidationError.from_dict(response.json())
-
-        return response_422
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(response=response),
     )
 
 
@@ -72,7 +65,8 @@ def sync_detailed(
         multipart_data (List[File]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -89,7 +83,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 def sync(
@@ -105,7 +99,8 @@ def sync(
         multipart_data (List[File]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -131,7 +126,8 @@ async def asyncio_detailed(
         multipart_data (List[File]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -146,7 +142,7 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio(
@@ -162,7 +158,8 @@ async def asyncio(
         multipart_data (List[File]):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 import httpx
 
@@ -36,7 +36,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Any:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -50,7 +50,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, H
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -96,7 +96,7 @@ def sync(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Upload multiple files
 
      Upload several files in the same request
@@ -109,7 +109,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return sync_detailed(
@@ -122,7 +122,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Response[Union[Any, HTTPValidationError, None]]:
+) -> Response[Any]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -135,7 +135,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError, None]]
+        Response[Any]
     """
 
     kwargs = _get_kwargs(
@@ -153,7 +153,7 @@ async def asyncio(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Union[Any, HTTPValidationError, None]:
+) -> Any:
     """Upload multiple files
 
      Upload several files in the same request
@@ -166,7 +166,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError, None]
+        Any
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_multiple_files_tests_upload_post.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 import httpx
 
@@ -36,7 +36,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, HTTPValidationError]]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Union[Any, HTTPValidationError, None]:
     if response.status_code == HTTPStatus.OK:
         response_200 = response.json()
         return response_200
@@ -50,7 +50,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Uni
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError]]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, HTTPValidationError, None]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -63,7 +63,7 @@ def sync_detailed(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -96,7 +96,7 @@ def sync(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -109,7 +109,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return sync_detailed(
@@ -122,7 +122,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Response[Union[Any, HTTPValidationError]]:
+) -> Response[Union[Any, HTTPValidationError, None]]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -135,7 +135,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, HTTPValidationError]]
+        Response[Union[Any, HTTPValidationError, None]]
     """
 
     kwargs = _get_kwargs(
@@ -153,7 +153,7 @@ async def asyncio(
     *,
     client: Client,
     multipart_data: List[File],
-) -> Optional[Union[Any, HTTPValidationError]]:
+) -> Union[Any, HTTPValidationError, None]:
     """Upload multiple files
 
      Upload several files in the same request
@@ -166,7 +166,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, HTTPValidationError]
+        Union[Any, HTTPValidationError, None]
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -48,7 +48,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[Non
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
     )
 
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any]:
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:
@@ -43,7 +43,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Any
         return None
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[Any]:
+def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -56,7 +56,7 @@ def sync_detailed(
     *,
     client: Client,
     import_: str,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         import_ (str):
@@ -66,7 +66,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(
@@ -86,7 +86,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     import_: str,
-) -> Response[Any]:
+) -> Response[None]:
     """
     Args:
         import_ (str):
@@ -96,7 +96,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Any]
+        Response[None]
     """
 
     kwargs = _get_kwargs(

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 
@@ -34,7 +34,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[None]:
+def _parse_response(*, client: Client, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
     if client.raise_on_unexpected_status:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -34,21 +34,19 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> None:
+def _parse_response(*, response: httpx.Response) -> None:
     if response.status_code == HTTPStatus.OK:
         return None
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response.raise_for_status()
+    raise errors.UnexpectedStatus(response.status_code, response.content)
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[None]:
+def _build_response(*, response: httpx.Response) -> Response[None]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response(response=response),  # type: ignore[func-returns-value]
     )
 
 
@@ -62,7 +60,8 @@ def sync_detailed(
         import_ (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -79,7 +78,7 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)
 
 
 async def asyncio_detailed(
@@ -92,7 +91,8 @@ async def asyncio_detailed(
         import_ (str):
 
     Raises:
-        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.HTTPStatusError: If the server returns an error status code.
+        errors.UnexpectedStatus: If the server returns an undocumented status code.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
@@ -107,4 +107,4 @@ async def asyncio_detailed(
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
         response = await _client.request(**kwargs)
 
-    return _build_response(client=client, response=response)
+    return _build_response(response=response)

--- a/end_to_end_tests/golden-record/my_test_api_client/client.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/client.py
@@ -18,6 +18,7 @@ class Client:
             but can be set to False for testing purposes.
         raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
             status code that was not documented in the source OpenAPI document.
+            Setting this has no effect, because it was already set in the client generation config.
         follow_redirects: Whether or not to follow redirects. Default value is False.
     """
 

--- a/end_to_end_tests/golden-record/my_test_api_client/types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/types.py
@@ -38,7 +38,7 @@ class Response(Generic[T]):
     status_code: HTTPStatus
     content: bytes
     headers: MutableMapping[str, str]
-    parsed: Optional[T]
+    parsed: T
 
 
 __all__ = ["File", "Response", "FileJsonType"]

--- a/integration-tests/integration_tests/api/body/post_body_multipart.py
+++ b/integration-tests/integration_tests/api/body/post_body_multipart.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -36,7 +36,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Optional[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Union[None, PostBodyMultipartResponse200, PublicError]:
     if response.status_code == HTTPStatus.OK:
         response_200 = PostBodyMultipartResponse200.from_dict(response.json())
 
@@ -53,7 +53,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Response[Union[None, PostBodyMultipartResponse200, PublicError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -66,7 +66,7 @@ def sync_detailed(
     *,
     client: Client,
     multipart_data: PostBodyMultipartMultipartData,
-) -> Response[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Response[Union[None, PostBodyMultipartResponse200, PublicError]]:
     """
     Args:
         multipart_data (PostBodyMultipartMultipartData):
@@ -76,7 +76,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[PostBodyMultipartResponse200, PublicError]]
+        Response[Union[None, PostBodyMultipartResponse200, PublicError]]
     """
 
     kwargs = _get_kwargs(
@@ -96,7 +96,7 @@ def sync(
     *,
     client: Client,
     multipart_data: PostBodyMultipartMultipartData,
-) -> Optional[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Union[None, PostBodyMultipartResponse200, PublicError]:
     """
     Args:
         multipart_data (PostBodyMultipartMultipartData):
@@ -106,7 +106,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[PostBodyMultipartResponse200, PublicError]
+        Union[None, PostBodyMultipartResponse200, PublicError]
     """
 
     return sync_detailed(
@@ -119,7 +119,7 @@ async def asyncio_detailed(
     *,
     client: Client,
     multipart_data: PostBodyMultipartMultipartData,
-) -> Response[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Response[Union[None, PostBodyMultipartResponse200, PublicError]]:
     """
     Args:
         multipart_data (PostBodyMultipartMultipartData):
@@ -129,7 +129,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[PostBodyMultipartResponse200, PublicError]]
+        Response[Union[None, PostBodyMultipartResponse200, PublicError]]
     """
 
     kwargs = _get_kwargs(
@@ -147,7 +147,7 @@ async def asyncio(
     *,
     client: Client,
     multipart_data: PostBodyMultipartMultipartData,
-) -> Optional[Union[PostBodyMultipartResponse200, PublicError]]:
+) -> Union[None, PostBodyMultipartResponse200, PublicError]:
     """
     Args:
         multipart_data (PostBodyMultipartMultipartData):
@@ -157,7 +157,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[PostBodyMultipartResponse200, PublicError]
+        Union[None, PostBodyMultipartResponse200, PublicError]
     """
 
     return (

--- a/integration-tests/integration_tests/api/parameters/post_parameters_header.py
+++ b/integration-tests/integration_tests/api/parameters/post_parameters_header.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 import httpx
 
@@ -43,7 +43,7 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: Client, response: httpx.Response
-) -> Optional[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Union[None, PostParametersHeaderResponse200, PublicError]:
     if response.status_code == HTTPStatus.OK:
         response_200 = PostParametersHeaderResponse200.from_dict(response.json())
 
@@ -60,7 +60,7 @@ def _parse_response(
 
 def _build_response(
     *, client: Client, response: httpx.Response
-) -> Response[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Response[Union[None, PostParametersHeaderResponse200, PublicError]]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -76,7 +76,7 @@ def sync_detailed(
     string_header: str,
     number_header: float,
     integer_header: int,
-) -> Response[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Response[Union[None, PostParametersHeaderResponse200, PublicError]]:
     """
     Args:
         boolean_header (bool):
@@ -89,7 +89,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[PostParametersHeaderResponse200, PublicError]]
+        Response[Union[None, PostParametersHeaderResponse200, PublicError]]
     """
 
     kwargs = _get_kwargs(
@@ -115,7 +115,7 @@ def sync(
     string_header: str,
     number_header: float,
     integer_header: int,
-) -> Optional[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Union[None, PostParametersHeaderResponse200, PublicError]:
     """
     Args:
         boolean_header (bool):
@@ -128,7 +128,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[PostParametersHeaderResponse200, PublicError]
+        Union[None, PostParametersHeaderResponse200, PublicError]
     """
 
     return sync_detailed(
@@ -147,7 +147,7 @@ async def asyncio_detailed(
     string_header: str,
     number_header: float,
     integer_header: int,
-) -> Response[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Response[Union[None, PostParametersHeaderResponse200, PublicError]]:
     """
     Args:
         boolean_header (bool):
@@ -160,7 +160,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[PostParametersHeaderResponse200, PublicError]]
+        Response[Union[None, PostParametersHeaderResponse200, PublicError]]
     """
 
     kwargs = _get_kwargs(
@@ -184,7 +184,7 @@ async def asyncio(
     string_header: str,
     number_header: float,
     integer_header: int,
-) -> Optional[Union[PostParametersHeaderResponse200, PublicError]]:
+) -> Union[None, PostParametersHeaderResponse200, PublicError]:
     """
     Args:
         boolean_header (bool):
@@ -197,7 +197,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[PostParametersHeaderResponse200, PublicError]
+        Union[None, PostParametersHeaderResponse200, PublicError]
     """
 
     return (

--- a/integration-tests/integration_tests/client.py
+++ b/integration-tests/integration_tests/client.py
@@ -18,6 +18,8 @@ class Client:
             but can be set to False for testing purposes.
         raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
             status code that was not documented in the source OpenAPI document.
+            This can also be set in the client generation config, to get return type annotations that do
+            not include None.
         follow_redirects: Whether or not to follow redirects. Default value is False.
     """
 

--- a/integration-tests/integration_tests/types.py
+++ b/integration-tests/integration_tests/types.py
@@ -38,7 +38,7 @@ class Response(Generic[T]):
     status_code: HTTPStatus
     content: bytes
     headers: MutableMapping[str, str]
-    parsed: Optional[T]
+    parsed: T
 
 
 __all__ = ["File", "Response", "FileJsonType"]

--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -263,7 +263,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
         # Generate Client
         client_path = self.package_dir / "client.py"
         client_template = self.env.get_template("client.py.jinja")
-        client_path.write_text(client_template.render(), encoding=self.file_encoding)
+        client_path.write_text(client_template.render(config=self.config), encoding=self.file_encoding)
 
         # Generate included Errors
         errors_path = self.package_dir / "errors.py"
@@ -295,9 +295,7 @@ class Project:  # pylint: disable=too-many-instance-attributes
             for endpoint in collection.endpoints:
                 module_path = tag_dir / f"{utils.PythonIdentifier(endpoint.name, self.config.field_prefix)}.py"
                 module_path.write_text(
-                    endpoint_template.render(
-                        endpoint=endpoint,
-                    ),
+                    endpoint_template.render(endpoint=endpoint, config=self.config),
                     encoding=self.file_encoding,
                 )
 

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -35,6 +35,8 @@ class Config(BaseModel):
     ]
     field_prefix: str = "field_"
     http_timeout: int = 5
+    raise_on_error_status: bool = False
+    raise_on_unexpected_status: bool = False
 
     @staticmethod
     def load_from_path(path: Path) -> "Config":

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -521,6 +521,8 @@ class Endpoint:
         types.add("None")
         if len(types) == 1:
             return next(iter(types))
+        if "Any" in types:
+            return "Any"  # Any includes all other types
         return f"Union[{', '.join(sorted(types))}]"
 
     def iter_all_parameters(self) -> Iterator[Property]:

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -516,12 +516,12 @@ class Endpoint:
 
     def response_type(self) -> str:
         """Get the Python type of any response from this endpoint"""
-        types = sorted({response.prop.get_type_string(quoted=False) for response in self.responses})
-        if len(types) == 0:
-            return "Any"
+        types = {response.prop.get_type_string(quoted=False) for response in self.responses}
+        # We can always return None if client.raise_on_unexpected_status is unset
+        types.add("None")
         if len(types) == 1:
-            return self.responses[0].prop.get_type_string(quoted=False)
-        return f"Union[{', '.join(types)}]"
+            return next(iter(types))
+        return f"Union[{', '.join(sorted(types))}]"
 
     def iter_all_parameters(self) -> Iterator[Property]:
         """Iterate through all the parameters of this endpoint"""

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -9,7 +9,7 @@ from .. import Config
 from .. import schema as oai
 from ..utils import PythonIdentifier
 from .errors import ParseError, PropertyError
-from .properties import AnyProperty, Property, Schemas, property_from_data
+from .properties import NoneProperty, Property, Schemas, property_from_data
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -40,7 +40,7 @@ def empty_response(
     """Return an untyped response, for when no response type is defined"""
     return Response(
         status_code=status_code,
-        prop=AnyProperty(
+        prop=NoneProperty(
             name=response_name,
             default=None,
             nullable=False,

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -20,6 +20,21 @@ class Response:
     prop: Property
     source: str
 
+    def get_typed_source(self) -> str:
+        """Get Python statement that parses the response and returns the correct type.
+
+        This might include a type cast if necessary (e.g. if we parse JSON
+        that can only be a string according to the OpenAPI schema)
+        """
+        if self.source == self.prop.get_type_string():
+            # No cast needed e.g. for `None` and `None`.
+            return self.source
+        if self.source == "response.json()" and self.prop.get_type_string() == "Any":
+            # response.json() is often used for untyped responses and already has
+            # the `Any` return type annotation.
+            return self.source
+        return f"cast({self.prop.get_type_string()}, {self.source})"
+
 
 def _source_by_content_type(content_type: str) -> Optional[str]:
     known_content_types = {

--- a/openapi_python_client/templates/client.py.jinja
+++ b/openapi_python_client/templates/client.py.jinja
@@ -16,6 +16,12 @@ class Client:
             but can be set to False for testing purposes.
         raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
             status code that was not documented in the source OpenAPI document.
+{% if config.raise_on_unexpected_status %}
+            Setting this has no effect, because it was already set in the client generation config.
+{% else %}
+            This can also be set in the client generation config, to get return type annotations that do
+            not include None.
+{% endif %}
         follow_redirects: Whether or not to follow redirects. Default value is False.
     """
 

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -141,7 +141,7 @@ json_body=json_body,
 {% endfor %}
 {% endmacro %}
 
-{% macro docstring_content(endpoint, return_string, is_detailed) %}
+{% macro docstring_content(endpoint, return_string, config, is_detailed) %}
 {% if endpoint.summary %}{{ endpoint.summary | wordwrap(100)}}
 
 {% endif -%}
@@ -161,7 +161,14 @@ Args:
 
 {% endif %}
 Raises:
+{% if config.raise_on_error_status %}
+    httpx.HTTPStatusError: If the server returns an error status code.
+{% endif %}
+{% if config.raise_on_unexpected_status %}
+    errors.UnexpectedStatus: If the server returns an undocumented status code.
+{% else %}
     errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+{% endif %}
     httpx.TimeoutException: If the request takes longer than Client.timeout.
 
 Returns:
@@ -172,6 +179,6 @@ Returns:
 {% endif %}
 {% endmacro %}
 
-{% macro docstring(endpoint, return_string, is_detailed) %}
-{{ safe_docstring(docstring_content(endpoint, return_string, is_detailed)) }}
+{% macro docstring(endpoint, return_string, config, is_detailed) %}
+{{ safe_docstring(docstring_content(endpoint, return_string, config, is_detailed)) }}
 {% endmacro %}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -67,7 +67,7 @@ def _parse_response(*, client: Client, response: httpx.Response) -> Optional[{{ 
         {% if prop_template.construct %}
         {{ prop_template.construct(response.prop, response.source) | indent(8) }}
         {% else %}
-        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source }})
+        {{ response.prop.python_name }} = {{ response.get_typed_source() }}
         {% endif %}
         return {{ response.prop.python_name }}
         {% else %}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -15,7 +15,7 @@ from ... import errors
     arguments, client, kwargs, parse_response, docstring %}
 
 {% set return_string = endpoint.response_type() %}
-{% set parsed_responses = (endpoint.responses | length > 0) and return_string not in ("Any", "None") %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "None" %}
 
 def _get_kwargs(
     {{ arguments(endpoint) | indent(4) }}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -85,7 +85,12 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ 
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
+        {% if parsed_responses %}
         parsed=_parse_response(client=client, response=response),
+        {% else %}
+        {# If _parse_response() returns None, mypy complains: https://github.com/python/mypy/issues/6549 #}
+        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        {% endif %}
     )
 
 

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -15,7 +15,7 @@ from ... import errors
     arguments, client, kwargs, parse_response, docstring %}
 
 {% set return_string = endpoint.response_type() %}
-{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
+{% set parsed_responses = (endpoint.responses | length > 0) and return_string not in ("Any", "None") %}
 
 def _get_kwargs(
     {{ arguments(endpoint) | indent(4) }}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -14,8 +14,16 @@ from ... import errors
 {% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params, json_body, multipart_body,
     arguments, client, kwargs, parse_response, docstring %}
 
-{% set return_string = endpoint.response_type() %}
-{% set parsed_responses = (endpoint.responses | length > 0) and return_string != "None" %}
+{% set return_string = endpoint.response_type(include_errors=not config.raise_on_error_status,
+                                              include_unexpected=not config.raise_on_unexpected_status) %}
+{% set responses = endpoint.responses %}
+{% if config.raise_on_error_status %}
+{% set responses = endpoint.responses | selectattr("status_code", "lessthan", 400) | list %}
+{% endif %}
+{% set parsed_responses = (responses | length > 0) and return_string != "None" %}
+
+{% set accept_client = "" if config.raise_on_unexpected_status else "client: Client, " %}
+{% set pass_client = "" if config.raise_on_unexpected_status else "client=client, " %}
 
 def _get_kwargs(
     {{ arguments(endpoint) | indent(4) }}
@@ -60,8 +68,8 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_string }}:
-    {% for response in endpoint.responses %}
+def _parse_response(*, {{ accept_client }}response: httpx.Response) -> {{ return_string }}:
+    {% for response in responses %}
     if response.status_code == HTTPStatus.{{ response.status_code.name }}:
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
         {% if prop_template.construct %}
@@ -74,22 +82,29 @@ def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_st
         return None
         {% endif %}
     {% endfor %}
+    {% if config.raise_on_error_status %}
+    response.raise_for_status()
+    {% endif %}
+    {% if config.raise_on_unexpected_status %}
+    raise errors.UnexpectedStatus(response.status_code, response.content)
+    {% else %}
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
         return None
+    {% endif %}
 
 
-def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ return_string }}]:
+def _build_response(*, {{ accept_client }}response: httpx.Response) -> Response[{{ return_string }}]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
         headers=response.headers,
         {% if parsed_responses %}
-        parsed=_parse_response(client=client, response=response),
+        parsed=_parse_response({{ pass_client }}response=response),
         {% else %}
         {# If _parse_response() returns None, mypy complains: https://github.com/python/mypy/issues/6549 #}
-        parsed=_parse_response(client=client, response=response),  # type: ignore[func-returns-value]
+        parsed=_parse_response({{ pass_client }}response=response),  # type: ignore[func-returns-value]
         {% endif %}
     )
 
@@ -97,7 +112,7 @@ def _build_response(*, client: Client, response: httpx.Response) -> Response[{{ 
 def sync_detailed(
     {{ arguments(endpoint) | indent(4) }}
 ) -> Response[{{ return_string }}]:
-    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+    {{ docstring(endpoint, return_string, config, is_detailed=true) | indent(4) }}
 
     kwargs = _get_kwargs(
         {{ kwargs(endpoint) }}
@@ -108,13 +123,13 @@ def sync_detailed(
         **kwargs,
     )
 
-    return _build_response(client=client, response=response)
+    return _build_response({{ pass_client }}response=response)
 
 {% if parsed_responses %}
 def sync(
     {{ arguments(endpoint) | indent(4) }}
 ) -> {{ return_string }}:
-    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+    {{ docstring(endpoint, return_string, config, is_detailed=false) | indent(4) }}
 
     return sync_detailed(
         {{ kwargs(endpoint) }}
@@ -124,7 +139,7 @@ def sync(
 async def asyncio_detailed(
     {{ arguments(endpoint) | indent(4) }}
 ) -> Response[{{ return_string }}]:
-    {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
+    {{ docstring(endpoint, return_string, config, is_detailed=true) | indent(4) }}
 
     kwargs = _get_kwargs(
         {{ kwargs(endpoint) }}
@@ -135,13 +150,13 @@ async def asyncio_detailed(
             **kwargs
         )
 
-    return _build_response(client=client, response=response)
+    return _build_response({{ pass_client }}response=response)
 
 {% if parsed_responses %}
 async def asyncio(
     {{ arguments(endpoint) | indent(4) }}
 ) -> {{ return_string }}:
-    {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
+    {{ docstring(endpoint, return_string, config, is_detailed=false) | indent(4) }}
 
     return (await asyncio_detailed(
         {{ kwargs(endpoint) }}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -60,7 +60,7 @@ def _get_kwargs(
     }
 
 
-def _parse_response(*, client: Client, response: httpx.Response) -> Optional[{{ return_string }}]:
+def _parse_response(*, client: Client, response: httpx.Response) -> {{ return_string }}:
     {% for response in endpoint.responses %}
     if response.status_code == HTTPStatus.{{ response.status_code.name }}:
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
@@ -113,7 +113,7 @@ def sync_detailed(
 {% if parsed_responses %}
 def sync(
     {{ arguments(endpoint) | indent(4) }}
-) -> Optional[{{ return_string }}]:
+) -> {{ return_string }}:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
 
     return sync_detailed(
@@ -140,7 +140,7 @@ async def asyncio_detailed(
 {% if parsed_responses %}
 async def asyncio(
     {{ arguments(endpoint) | indent(4) }}
-) -> Optional[{{ return_string }}]:
+) -> {{ return_string }}:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
 
     return (await asyncio_detailed(

--- a/openapi_python_client/templates/types.py.jinja
+++ b/openapi_python_client/templates/types.py.jinja
@@ -39,7 +39,7 @@ class Response(Generic[T]):
     status_code: HTTPStatus
     content: bytes
     headers: MutableMapping[str, str]
-    parsed: Optional[T]
+    parsed: T
 
 
 __all__ = ["File", "Response", "FileJsonType"]

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -1205,7 +1205,11 @@ class TestEndpoint:
 
     @pytest.mark.parametrize(
         "response_types, expected",
-        (([], "Any"), (["Something"], "Something"), (["First", "Second", "Second"], "Union[First, Second]")),
+        (
+            ([], "None"),
+            (["Something"], "Union[None, Something]"),
+            (["First", "Second", "Second"], "Union[First, None, Second]"),
+        ),
     )
     def test_response_type(self, response_types, expected):
         endpoint = self.make_endpoint()

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -7,7 +7,7 @@ from openapi_python_client.parser.properties import AnyProperty, Schemas, String
 MODULE_NAME = "openapi_python_client.parser.responses"
 
 
-def test_response_from_data_no_content(any_property_factory):
+def test_response_from_data_no_content(none_property_factory):
     from openapi_python_client.parser.responses import Response, response_from_data
 
     response, schemas = response_from_data(
@@ -20,7 +20,7 @@ def test_response_from_data_no_content(any_property_factory):
 
     assert response == Response(
         status_code=200,
-        prop=any_property_factory(
+        prop=none_property_factory(
             name="response_200",
             default=None,
             nullable=False,
@@ -31,7 +31,7 @@ def test_response_from_data_no_content(any_property_factory):
     )
 
 
-def test_response_from_data_reference(any_property_factory):
+def test_response_from_data_reference(none_property_factory):
     from openapi_python_client.parser.responses import Response, response_from_data
 
     response, schemas = response_from_data(
@@ -44,7 +44,7 @@ def test_response_from_data_reference(any_property_factory):
 
     assert response == Response(
         status_code=200,
-        prop=any_property_factory(
+        prop=none_property_factory(
             name="response_200",
             default=None,
             nullable=False,
@@ -65,7 +65,7 @@ def test_response_from_data_unsupported_content_type():
     assert response == ParseError(data=data, detail="Unsupported content_type {'blah': None}")
 
 
-def test_response_from_data_no_content_schema(any_property_factory):
+def test_response_from_data_no_content_schema(none_property_factory):
     from openapi_python_client.parser.responses import Response, response_from_data
 
     data = oai.Response.construct(description="", content={"application/json": oai.MediaType.construct()})
@@ -75,7 +75,7 @@ def test_response_from_data_no_content_schema(any_property_factory):
 
     assert response == Response(
         status_code=200,
-        prop=any_property_factory(
+        prop=none_property_factory(
             name="response_200",
             default=None,
             nullable=False,


### PR DESCRIPTION
`raise_on_error_status` raises a `httpx.HTTPStatusError` on all error
response codes without decoding. This can later be improved to add an exception that includes the decoded content, or to even raise different exception types for each response code (see https://github.com/openapi-generators/openapi-python-client/pull/736#issuecomment-1493038758).

`raise_on_unexpected_status` is identical to the existing
`Client.raise_on_unexpected_status` runtime setting, but leads to better
return type annotations.

Closes https://github.com/openapi-generators/openapi-python-client/issues/491

This is a rework of https://github.com/openapi-generators/openapi-python-client/pull/736, with the main intention of reducing the generated `sync` and `asyncio` functions' return type annotations to documented successful responses.

Includes the commits from #742, which should be merged first.