### PR TITLE
Allow to override tag using `x-code-tag`

### DIFF
--- a/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/tests/__init__.py
+++ b/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/tests/__init__.py
@@ -10,6 +10,7 @@ from . import (
     get_basic_list_of_floats,
     get_basic_list_of_integers,
     get_basic_list_of_strings,
+    get_tag_override,
     get_user_list,
     int_enum_tests_int_enum_post,
     json_body_tests_json_body_post,
@@ -152,6 +153,10 @@ class TestsEndpoints:
         Test optional cookie parameters
         """
         return token_with_cookie_auth_token_with_cookie_get
+
+    @classmethod
+    def get_tag_override(cls) -> types.ModuleType:
+        return get_tag_override
 
     @classmethod
     def callback_test(cls) -> types.ModuleType:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_tag_override.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_tag_override.py
@@ -1,0 +1,77 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> Dict[str, Any]:
+    pass
+
+    return {
+        "method": "get",
+        "url": "/tag_override",
+    }
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == HTTPStatus.OK:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Any]:
+    """
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Any]:
+    """
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -947,6 +947,17 @@
         }
       }
     },
+    "/tag_override": {
+      "get": {
+        "tags": ["tests"],
+        "x-code-tag": "tag_override",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
     "/multiple-path-parameters/{param4}/something/{param2}/{param1}/{param3}": {
       "description": "Test that multiple path parameters are ordered by appearance in path",
       "get": {

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -58,7 +58,9 @@ class EndpointCollection:
                 operation: Optional[oai.Operation] = getattr(path_data, method)
                 if operation is None:
                     continue
-                tag = utils.PythonIdentifier(value=operation.__dict__.get('x-code-tag') or (operation.tags or ["default"])[0], prefix="tag")
+                tag = utils.PythonIdentifier(
+                    value=operation.__dict__.get("x-code-tag") or (operation.tags or ["default"])[0], prefix="tag"
+                )
                 collection = endpoints_by_tag.setdefault(tag, EndpointCollection(tag=tag))
                 endpoint, schemas, parameters = Endpoint.from_data(
                     data=operation,

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -58,7 +58,7 @@ class EndpointCollection:
                 operation: Optional[oai.Operation] = getattr(path_data, method)
                 if operation is None:
                     continue
-                tag = utils.PythonIdentifier(value=(operation.tags or ["default"])[0], prefix="tag")
+                tag = utils.PythonIdentifier(value=operation.__dict__.get('x-code-tag') or (operation.tags or ["default"])[0], prefix="tag")
                 collection = endpoints_by_tag.setdefault(tag, EndpointCollection(tag=tag))
                 endpoint, schemas, parameters = Endpoint.from_data(
                     data=operation,


### PR DESCRIPTION
Allow to override tag as the grouping mechanism per endpoint using the 'x-code-tag' property on the operation
