### PR TITLE
feat: Support content-type with attributes (#655 #809). Thanks @sherbang!

### DIFF
--- a/end_to_end_tests/openapi.json
+++ b/end_to_end_tests/openapi.json
@@ -1272,7 +1272,7 @@
           "200": {
             "description": "Successful Response",
             "content": {
-              "application/json": {
+              "application/json; version=1.2.3": {
                 "schema": {}
               }
             }

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -5,6 +5,8 @@ from typing import Optional, Tuple, Union
 
 from attrs import define
 
+from openapi_python_client import utils
+
 from .. import Config
 from .. import schema as oai
 from ..utils import PythonIdentifier
@@ -22,6 +24,8 @@ class Response:
 
 
 def _source_by_content_type(content_type: str) -> Optional[str]:
+    content_type = utils.get_content_type(content_type)
+
     known_content_types = {
         "application/json": "response.json()",
         "application/octet-stream": "response.content",

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -68,7 +68,9 @@ def test_response_from_data_unsupported_content_type():
 def test_response_from_data_no_content_schema(any_property_factory):
     from openapi_python_client.parser.responses import Response, response_from_data
 
-    data = oai.Response.model_construct(description="", content={"application/json": oai.MediaType.model_construct()})
+    data = oai.Response.model_construct(
+        description="", content={"application/vnd.api+json; version=2.2": oai.MediaType.model_construct()}
+    )
     response, schemas = response_from_data(
         status_code=200, data=data, schemas=Schemas(), parent_name="parent", config=MagicMock()
     )


### PR DESCRIPTION
This resolves  #655  #809

Content-type with a version attribute appears to be very common in OpenAPI schemas generated for .Net applications.