### PR TITLE
Make enum models more user friendly

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -233,9 +233,9 @@ class AModel:
         from ..models.model_with_union_property import ModelWithUnionProperty
 
         d = src_dict.copy()
-        an_enum_value = AnEnum(d.pop("an_enum_value"))
+        an_enum_value = AnEnum.from_val(d.pop("an_enum_value"))
 
-        an_allof_enum_with_overridden_default = AnAllOfEnum(d.pop("an_allof_enum_with_overridden_default"))
+        an_allof_enum_with_overridden_default = AnAllOfEnum.from_val(d.pop("an_allof_enum_with_overridden_default"))
 
         def _parse_a_camel_date_time(data: object) -> Union[datetime.date, datetime.datetime]:
             try:
@@ -288,7 +288,7 @@ class AModel:
         if isinstance(_an_optional_allof_enum, Unset):
             an_optional_allof_enum = UNSET
         else:
-            an_optional_allof_enum = AnAllOfEnum(_an_optional_allof_enum)
+            an_optional_allof_enum = AnAllOfEnum.from_val(_an_optional_allof_enum)
 
         nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
@@ -296,7 +296,7 @@ class AModel:
             nested_list_of_enums_item = []
             _nested_list_of_enums_item = nested_list_of_enums_item_data
             for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
-                nested_list_of_enums_item_item = DifferentEnum(nested_list_of_enums_item_item_data)
+                nested_list_of_enums_item_item = DifferentEnum.from_val(nested_list_of_enums_item_item_data)
 
                 nested_list_of_enums_item.append(nested_list_of_enums_item_item)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_with_properties_reference_that_are_not_object.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_with_properties_reference_that_are_not_object.py
@@ -216,7 +216,9 @@ class AModelWithPropertiesReferenceThatAreNotObject:
         enum_properties_ref = []
         _enum_properties_ref = d.pop("enum_properties_ref")
         for componentsschemas_an_other_array_of_enum_item_data in _enum_properties_ref:
-            componentsschemas_an_other_array_of_enum_item = AnEnum(componentsschemas_an_other_array_of_enum_item_data)
+            componentsschemas_an_other_array_of_enum_item = AnEnum.from_val(
+                componentsschemas_an_other_array_of_enum_item_data
+            )
 
             enum_properties_ref.append(componentsschemas_an_other_array_of_enum_item)
 
@@ -262,7 +264,7 @@ class AModelWithPropertiesReferenceThatAreNotObject:
         enum_properties = []
         _enum_properties = d.pop("enum_properties")
         for componentsschemas_an_array_of_enum_item_data in _enum_properties:
-            componentsschemas_an_array_of_enum_item = AnEnum(componentsschemas_an_array_of_enum_item_data)
+            componentsschemas_an_array_of_enum_item = AnEnum.from_val(componentsschemas_an_array_of_enum_item_data)
 
             enum_properties.append(componentsschemas_an_array_of_enum_item)
 
@@ -301,7 +303,7 @@ class AModelWithPropertiesReferenceThatAreNotObject:
 
         bytestream_properties = cast(List[str], d.pop("bytestream_properties"))
 
-        enum_property_ref = AnEnum(d.pop("enum_property_ref"))
+        enum_property_ref = AnEnum.from_val(d.pop("enum_property_ref"))
 
         str_property_ref = d.pop("str_property_ref")
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type.py
@@ -54,7 +54,7 @@ class AllOfHasPropertiesButNoType:
         if isinstance(_type_enum, Unset):
             type_enum = UNSET
         else:
-            type_enum = AllOfHasPropertiesButNoTypeTypeEnum(_type_enum)
+            type_enum = AllOfHasPropertiesButNoTypeTypeEnum.from_val(_type_enum)
 
         all_of_has_properties_but_no_type = cls(
             a_sub_property=a_sub_property,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 
 class AllOfHasPropertiesButNoTypeTypeEnum(IntEnum):
@@ -7,3 +8,24 @@ class AllOfHasPropertiesButNoTypeTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(
+        cls, value: Union[int, str, "AllOfHasPropertiesButNoTypeTypeEnum"]
+    ) -> "AllOfHasPropertiesButNoTypeTypeEnum":
+        if isinstance(value, AllOfHasPropertiesButNoTypeTypeEnum):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model.py
@@ -54,7 +54,7 @@ class AllOfSubModel:
         if isinstance(_type_enum, Unset):
             type_enum = UNSET
         else:
-            type_enum = AllOfSubModelTypeEnum(_type_enum)
+            type_enum = AllOfSubModelTypeEnum.from_val(_type_enum)
 
         all_of_sub_model = cls(
             a_sub_property=a_sub_property,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 
 class AllOfSubModelTypeEnum(IntEnum):
@@ -7,3 +8,22 @@ class AllOfSubModelTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[int, str, "AllOfSubModelTypeEnum"]) -> "AllOfSubModelTypeEnum":
+        if isinstance(value, AllOfSubModelTypeEnum):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_all_of_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_all_of_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class AnAllOfEnum(str, Enum):
@@ -9,3 +10,16 @@ class AnAllOfEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "AnAllOfEnum"]) -> "AnAllOfEnum":
+        if isinstance(value, AnAllOfEnum):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return AnAllOfEnum(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class AnEnum(str, Enum):
@@ -7,3 +8,16 @@ class AnEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "AnEnum"]) -> "AnEnum":
+        if isinstance(value, AnEnum):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return AnEnum(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_enum_with_null.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_enum_with_null.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class AnEnumWithNull(str, Enum):
@@ -7,3 +8,16 @@ class AnEnumWithNull(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "AnEnumWithNull"]) -> "AnEnumWithNull":
+        if isinstance(value, AnEnumWithNull):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return AnEnumWithNull(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 
 class AnIntEnum(IntEnum):
@@ -8,3 +9,22 @@ class AnIntEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[int, str, "AnIntEnum"]) -> "AnIntEnum":
+        if isinstance(value, AnIntEnum):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model.py
@@ -56,14 +56,14 @@ class AnotherAllOfSubModel:
         if isinstance(_type, Unset):
             type = UNSET
         else:
-            type = AnotherAllOfSubModelType(_type)
+            type = AnotherAllOfSubModelType.from_val(_type)
 
         _type_enum = d.pop("type_enum", UNSET)
         type_enum: Union[Unset, AnotherAllOfSubModelTypeEnum]
         if isinstance(_type_enum, Unset):
             type_enum = UNSET
         else:
-            type_enum = AnotherAllOfSubModelTypeEnum(_type_enum)
+            type_enum = AnotherAllOfSubModelTypeEnum.from_val(_type_enum)
 
         another_all_of_sub_model = cls(
             another_sub_property=another_sub_property,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class AnotherAllOfSubModelType(str, Enum):
@@ -6,3 +7,16 @@ class AnotherAllOfSubModelType(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "AnotherAllOfSubModelType"]) -> "AnotherAllOfSubModelType":
+        if isinstance(value, AnotherAllOfSubModelType):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return AnotherAllOfSubModelType(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 
 class AnotherAllOfSubModelTypeEnum(IntEnum):
@@ -6,3 +7,22 @@ class AnotherAllOfSubModelTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[int, str, "AnotherAllOfSubModelTypeEnum"]) -> "AnotherAllOfSubModelTypeEnum":
+        if isinstance(value, AnotherAllOfSubModelTypeEnum):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
@@ -261,7 +261,7 @@ class BodyUploadFileTestsUploadPost:
         if isinstance(_some_enum, Unset):
             some_enum = UNSET
         else:
-            some_enum = DifferentEnum(_some_enum)
+            some_enum = DifferentEnum.from_val(_some_enum)
 
         body_upload_file_tests_upload_post = cls(
             some_file=some_file,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class DifferentEnum(str, Enum):
@@ -7,3 +8,16 @@ class DifferentEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "DifferentEnum"]) -> "DifferentEnum":
+        if isinstance(value, DifferentEnum):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return DifferentEnum(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_int_enum_header.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_int_enum_header.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 
 class GetLocationHeaderTypesIntEnumHeader(IntEnum):
@@ -8,3 +9,24 @@ class GetLocationHeaderTypesIntEnumHeader(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(
+        cls, value: Union[int, str, "GetLocationHeaderTypesIntEnumHeader"]
+    ) -> "GetLocationHeaderTypesIntEnumHeader":
+        if isinstance(value, GetLocationHeaderTypesIntEnumHeader):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_string_enum_header.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_string_enum_header.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 
 class GetLocationHeaderTypesStringEnumHeader(str, Enum):
@@ -8,3 +9,18 @@ class GetLocationHeaderTypesStringEnumHeader(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(
+        cls, value: Union[str, "GetLocationHeaderTypesStringEnumHeader"]
+    ) -> "GetLocationHeaderTypesStringEnumHeader":
+        if isinstance(value, GetLocationHeaderTypesStringEnumHeader):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return GetLocationHeaderTypesStringEnumHeader(value)

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_from_all_of.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_from_all_of.py
@@ -62,14 +62,14 @@ class ModelFromAllOf:
         if isinstance(_type, Unset):
             type = UNSET
         else:
-            type = AnotherAllOfSubModelType(_type)
+            type = AnotherAllOfSubModelType.from_val(_type)
 
         _type_enum = d.pop("type_enum", UNSET)
         type_enum: Union[Unset, AnotherAllOfSubModelTypeEnum]
         if isinstance(_type_enum, Unset):
             type_enum = UNSET
         else:
-            type_enum = AnotherAllOfSubModelTypeEnum(_type_enum)
+            type_enum = AnotherAllOfSubModelTypeEnum.from_val(_type_enum)
 
         another_sub_property = d.pop("another_sub_property", UNSET)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_refed.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_additional_properties_refed.py
@@ -30,7 +30,7 @@ class ModelWithAdditionalPropertiesRefed:
 
         additional_properties = {}
         for prop_name, prop_dict in d.items():
-            additional_property = AnEnum(prop_dict)
+            additional_property = AnEnum.from_val(prop_dict)
 
             additional_properties[prop_name] = additional_property
 

--- a/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/model_with_union_property.py
@@ -55,7 +55,7 @@ class ModelWithUnionProperty:
                 if isinstance(_a_property_type_0, Unset):
                     a_property_type_0 = UNSET
                 else:
-                    a_property_type_0 = AnEnum(_a_property_type_0)
+                    a_property_type_0 = AnEnum.from_val(_a_property_type_0)
 
                 return a_property_type_0
             except:  # noqa: E722
@@ -67,7 +67,7 @@ class ModelWithUnionProperty:
             if isinstance(_a_property_type_1, Unset):
                 a_property_type_1 = UNSET
             else:
-                a_property_type_1 = AnIntEnum(_a_property_type_1)
+                a_property_type_1 = AnIntEnum.from_val(_a_property_type_1)
 
             return a_property_type_1
 

--- a/openapi_python_client/templates/int_enum.py.jinja
+++ b/openapi_python_client/templates/int_enum.py.jinja
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Union
 
 class {{ enum.class_info.name }}(IntEnum):
     {% for key, value in enum.values.items() %}
@@ -7,3 +8,22 @@ class {{ enum.class_info.name }}(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[int, str, "{{enum.class_info.name}}"]) -> "{{ enum.class_info.name }}":
+        if isinstance(value, {{ enum.class_info.name }}):
+            return value
+
+        if isinstance(value, str):
+            value = value.lower()
+            for key in cls.__members__.keys():
+                if key.lower() == value:
+                    return cls[key]
+
+            # try to convert value to int
+            try:
+                value = int(value)
+            except ValueError:
+                pass
+
+        return cls(value)

--- a/openapi_python_client/templates/property_templates/enum_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/enum_property.py.jinja
@@ -1,5 +1,5 @@
 {% macro construct_function(property, source) %}
-{{ property.class_info.name }}({{ source }})
+{{ property.class_info.name }}.from_val({{ source }})
 {% endmacro %}
 
 {% from "property_templates/property_macros.py.jinja" import construct_template %}

--- a/openapi_python_client/templates/str_enum.py.jinja
+++ b/openapi_python_client/templates/str_enum.py.jinja
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Union
 
 class {{ enum.class_info.name }}(str, Enum):
     {% for key, value in enum.values|dictsort(true) %}
@@ -7,3 +8,16 @@ class {{ enum.class_info.name }}(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+    @classmethod
+    def from_val(cls, value: Union[str, "{{ enum.class_info.name }}"]) -> "{{ enum.class_info.name }}":
+        if isinstance(value, {{ enum.class_info.name }}):
+            return value
+
+        value = value.lower()
+
+        for enum in cls:
+            if enum.value.lower() == value:
+                return enum
+
+        return {{ enum.class_info.name }}(value)


### PR DESCRIPTION
Make enum models more user friendly

the underlying values stay the same, as does the string representation
but the values for from_dict or from payload that the user is giving can be a mix of the enum object, string representation (case insensitive) and the underlying value
