### PR TITLE
fix: add custom filter to enable adding python names to path

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -27,6 +27,7 @@ TEMPLATE_FILTERS = {
     "snakecase": utils.snake_case,
     "kebabcase": utils.kebab_case,
     "pascalcase": utils.pascal_case,
+    "convert_endpoint_path": utils.convert_endpoint_path,
     "any": any,
 }
 

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -26,7 +26,7 @@ from .properties import (
 from .properties.schemas import parameter_from_reference
 from .responses import Response, response_from_data
 
-_PATH_PARAM_REGEX = re.compile("{([a-zA-Z_][a-zA-Z0-9_]*)}")
+_PATH_PARAM_REGEX = re.compile("{([a-zA-Z_-][a-zA-Z0-9_-]*)}")
 
 
 def import_string_from_class(class_: Class, prefix: str = "") -> str:

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -29,9 +29,9 @@ def _get_kwargs(
     _kwargs: Dict[str, Any] = {
         "method": "{{ endpoint.method }}",
         {% if endpoint.path_parameters %}
-        "url": "{{ endpoint.path }}".format(
+        "url": "{{ endpoint | convert_endpoint_path }}".format(
         {%- for parameter in endpoint.path_parameters -%}
-        {{parameter.name}}={{parameter.python_name}},
+        {{parameter.python_name}}={{parameter.python_name}},
         {%- endfor -%}
         ),
         {% else %}

--- a/openapi_python_client/utils.py
+++ b/openapi_python_client/utils.py
@@ -118,3 +118,17 @@ def get_content_type(content_type: str) -> str | None:
         return None
 
     return parsed_content_type
+
+
+def convert_endpoint_path(endpoint) -> str:
+    """
+    Converts parameter names within the endpoint path to their python names.
+    """
+
+    endpoint_path_python_names = endpoint.path
+    for parameter in endpoint.path_parameters:
+        endpoint_path_python_names = endpoint_path_python_names.replace(
+            f'{{{parameter.name}}}',
+            f'{{{parameter.python_name}}}'
+        )
+    return endpoint_path_python_names


### PR DESCRIPTION
Fixes #976 and #578, and replaces #978.

@dbanty please choose your preferred approach between this and PR #986.

The original issue is that `openapi-python-client` throws `incorrect path templating` warnings when the path has a parameter with a hyphen and consequently fails to generate the endpoints.

---

The first commit ensures that hyphens are recognised as allowed delimiters in parameter path names. This allows the endpoints to be generated. 

However, this generates lines like these:

```python
def _get_kwargs(
    user_id: int,
) -> Dict[str, Any]:
    _kwargs: Dict[str, Any] = {
        "method": "post",
        "url": "/activitypub/user-id/{user-id}/inbox".format(user-id=user_id,),
    }
    return _kwargs
```

Since Python variable names cannot contain hyphens, the `user-id` parameter name here will trigger errors (starting with `ruff`).

---

The second commit creates a custom Jinja filter in `utils.py` and so that the parameter names in `endpoint.path` can be converted to their python names directly in `templates/endpoint_module.py.jinja`.

This fixes the issue and allows endpoints to be generated correctly. 

---

#986 is a different option for the second commit which instead replaces parameter names with their `python_name` in `__init__.py` and passes the modified path to `templates/endpoint_module.py.jinja`. 

Both approaches are equivalent and have been tested with different parameter names (snake case, camel case, kebab case, mixed).