### PR TITLE
Add response content to UnexpectedStatus exception

### DIFF
--- a/.changeset/add_response_content_to_unexpectedstatus_exception.md
+++ b/.changeset/add_response_content_to_unexpectedstatus_exception.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Add response content to `UnexpectedStatus` exception
+
+The error message for `UnexpectedStatus` exceptions will now include the UTF-8 decoded (ignoring errors) body of the response.
+
+PR #989 implements #840. Thanks @harabat!

--- a/end_to_end_tests/golden-record/my_test_api_client/errors.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/errors.py
@@ -8,7 +8,9 @@ class UnexpectedStatus(Exception):
         self.status_code = status_code
         self.content = content
 
-        super().__init__(f"Unexpected status code: {status_code}")
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
 
 
 __all__ = ["UnexpectedStatus"]

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/errors.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/errors.py
@@ -8,7 +8,9 @@ class UnexpectedStatus(Exception):
         self.status_code = status_code
         self.content = content
 
-        super().__init__(f"Unexpected status code: {status_code}")
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
 
 
 __all__ = ["UnexpectedStatus"]

--- a/integration-tests/integration_tests/errors.py
+++ b/integration-tests/integration_tests/errors.py
@@ -8,7 +8,9 @@ class UnexpectedStatus(Exception):
         self.status_code = status_code
         self.content = content
 
-        super().__init__(f"Unexpected status code: {status_code}")
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
 
 
 __all__ = ["UnexpectedStatus"]

--- a/openapi_python_client/templates/errors.py.jinja
+++ b/openapi_python_client/templates/errors.py.jinja
@@ -8,8 +8,7 @@ class UnexpectedStatus(Exception):
         self.content = content
 
         super().__init__(
-            f"Unexpected status code: {status_code}\n\n"
-            f"Response content:\n{content}"
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
         )
 
 __all__ = ["UnexpectedStatus"]

--- a/openapi_python_client/templates/errors.py.jinja
+++ b/openapi_python_client/templates/errors.py.jinja
@@ -7,6 +7,9 @@ class UnexpectedStatus(Exception):
         self.status_code = status_code
         self.content = content
 
-        super().__init__(f"Unexpected status code: {status_code}")
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\n"
+            f"Response content:\n{content}"
+        )
 
 __all__ = ["UnexpectedStatus"]


### PR DESCRIPTION
Fixes #839 and #840

This is a simple change that adds the response content to the `UnexpectedStatus` exception, which is currently the most upvoted feature in [Discussions](https://github.com/openapi-generators/openapi-python-client/discussions).