### PR TITLE
validate value of 'const' properties (helps with discriminated unions)

### DIFF
--- a/.changeset/const_values_are_now_validated_at_runtime.md
+++ b/.changeset/const_values_are_now_validated_at_runtime.md
@@ -1,0 +1,10 @@
+---
+default: major
+---
+
+# `const` values in responses are now validated at runtime
+
+Prior to this version, `const` values returned from servers were assumed to always be correct. Now, if a server returns 
+an unexpected value, the client will raise a `ValueError`. This should enable better usage with `oneOf`.
+
+PR #1024. Thanks @peter-greenatlas!

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
@@ -45,7 +45,13 @@ def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Literal["Why have a fixed response? I dunno"]]:
     if response.status_code == HTTPStatus.OK:
-        response_200 = cast(Literal["Why have a fixed response? I dunno"], response.json())
+        _response_200 = response.json()
+        if _response_200 != "Why have a fixed response? I dunno":
+            raise ValueError(
+                f"response_200 must match const 'Why have a fixed response? I dunno', got '{ _response_200 }'"
+            )
+        response_200 = cast(Literal["Why have a fixed response? I dunno"], _response_200)
+
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
@@ -45,13 +45,11 @@ def _parse_response(
     *, client: Union[AuthenticatedClient, Client], response: httpx.Response
 ) -> Optional[Literal["Why have a fixed response? I dunno"]]:
     if response.status_code == HTTPStatus.OK:
-        _response_200 = response.json()
-        if _response_200 != "Why have a fixed response? I dunno":
+        response_200 = cast(Literal["Why have a fixed response? I dunno"], response.json())
+        if response_200 != "Why have a fixed response? I dunno":
             raise ValueError(
-                f"response_200 must match const 'Why have a fixed response? I dunno', got '{ _response_200 }'"
+                f"response_200 must match const 'Why have a fixed response? I dunno', got '{response_200}'"
             )
-        response_200 = cast(Literal["Why have a fixed response? I dunno"], _response_200)
-
         return response_200
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_const_path_body.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_const_path_body.py
@@ -46,16 +46,34 @@ class PostConstPathBody:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        required = d.pop("required")
+        _required = d.pop("required")
+        if _required != "this always goes in the body":
+            raise ValueError(f"required must match const 'this always goes in the body', got '{ _required }'")
+        required = cast(Literal["this always goes in the body"], _required)
 
         def _parse_nullable(data: object) -> Union[Literal["this or null goes in the body"], None]:
             if data is None:
                 return data
+            _nullable_type_1 = data
+            if _nullable_type_1 != "this or null goes in the body":
+                raise ValueError(
+                    f"nullable_type_1 must match const 'this or null goes in the body', got '{ _nullable_type_1 }'"
+                )
+            nullable_type_1 = cast(Literal["this or null goes in the body"], _nullable_type_1)
+
+            return nullable_type_1
             return cast(Union[Literal["this or null goes in the body"], None], data)
 
         nullable = _parse_nullable(d.pop("nullable"))
 
-        optional = d.pop("optional", UNSET)
+        _optional = d.pop("optional", UNSET)
+        optional: Union[Literal["this sometimes goes in the body"], Unset]
+        if isinstance(_optional, Unset):
+            optional = UNSET
+        else:
+            if _optional != "this sometimes goes in the body":
+                raise ValueError(f"optional must match const 'this sometimes goes in the body', got '{ _optional }'")
+            optional = cast(Union[Literal["this sometimes goes in the body"], Unset], _optional)
 
         post_const_path_body = cls(
             required=required,

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_const_path_body.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_const_path_body.py
@@ -46,34 +46,26 @@ class PostConstPathBody:
     @classmethod
     def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
         d = src_dict.copy()
-        _required = d.pop("required")
-        if _required != "this always goes in the body":
-            raise ValueError(f"required must match const 'this always goes in the body', got '{ _required }'")
-        required = cast(Literal["this always goes in the body"], _required)
+        required = cast(Literal["this always goes in the body"], d.pop("required"))
+        if required != "this always goes in the body":
+            raise ValueError(f"required must match const 'this always goes in the body', got '{required}'")
 
         def _parse_nullable(data: object) -> Union[Literal["this or null goes in the body"], None]:
             if data is None:
                 return data
-            _nullable_type_1 = data
-            if _nullable_type_1 != "this or null goes in the body":
+            nullable_type_1 = cast(Literal["this or null goes in the body"], data)
+            if nullable_type_1 != "this or null goes in the body":
                 raise ValueError(
-                    f"nullable_type_1 must match const 'this or null goes in the body', got '{ _nullable_type_1 }'"
+                    f"nullable_type_1 must match const 'this or null goes in the body', got '{nullable_type_1}'"
                 )
-            nullable_type_1 = cast(Literal["this or null goes in the body"], _nullable_type_1)
-
             return nullable_type_1
             return cast(Union[Literal["this or null goes in the body"], None], data)
 
         nullable = _parse_nullable(d.pop("nullable"))
 
-        _optional = d.pop("optional", UNSET)
-        optional: Union[Literal["this sometimes goes in the body"], Unset]
-        if isinstance(_optional, Unset):
-            optional = UNSET
-        else:
-            if _optional != "this sometimes goes in the body":
-                raise ValueError(f"optional must match const 'this sometimes goes in the body', got '{ _optional }'")
-            optional = cast(Union[Literal["this sometimes goes in the body"], Unset], _optional)
+        optional = cast(Union[Literal["this sometimes goes in the body"], Unset], d.pop("optional", UNSET))
+        if optional != "this sometimes goes in the body" and not isinstance(optional, Unset):
+            raise ValueError(f"optional must match const 'this sometimes goes in the body', got '{optional}'")
 
         post_const_path_body = cls(
             required=required,

--- a/openapi_python_client/parser/properties/const.py
+++ b/openapi_python_client/parser/properties/const.py
@@ -12,7 +12,7 @@ from .string import StringProperty
 
 @define
 class ConstProperty(PropertyProtocol):
-    """A property representing a Union (anyOf) of other properties"""
+    """A property representing a const value"""
 
     name: str
     required: bool
@@ -21,6 +21,7 @@ class ConstProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: None
+    template: ClassVar[str] = "const_property.py.jinja"
 
     @classmethod
     def build(

--- a/openapi_python_client/parser/properties/const.py
+++ b/openapi_python_client/parser/properties/const.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, overload
+from typing import Any, ClassVar, overload
 
 from attr import define
 

--- a/openapi_python_client/templates/property_templates/const_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/const_property.py.jinja
@@ -1,19 +1,5 @@
-{% macro construct_impl(property, source) %}
-if {{ source }} != {{ property.value }}:
-    raise ValueError(f"{{ property.name }} must match const {{ property.value }}, got '{ {{ source }} }'")
-{{ property.python_name }} = cast({{ property.get_type_string() }} , {{ source }})
-{%- endmacro %}
-
-
 {% macro construct(property, source) %}
-_{{ property.python_name }} = {{ source }}
-{% if property.required %}
-{{ construct_impl(property, "_" + property.python_name) }}
-{% else %}
-{{ property.python_name }} : {{ property.get_type_string() }}
-if isinstance(_{{ property.python_name }}, Unset):
-    {{ property.python_name }} = UNSET
-else:
-    {{ construct_impl(property, "_" + property.python_name) | indent }}
-{% endif %}
+{{ property.python_name }} = cast({{ property.get_type_string() }} , {{ source }})
+if {{ property.python_name }} != {{ property.value }}{% if not property.required %}and not isinstance({{ property.python_name }}, Unset){% endif %}:
+    raise ValueError(f"{{ property.name }} must match const {{ property.value }}, got '{{'{' + property.python_name + '}' }}'")
 {%- endmacro %}

--- a/openapi_python_client/templates/property_templates/const_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/const_property.py.jinja
@@ -1,0 +1,19 @@
+{% macro construct_impl(property, source) %}
+if {{ source }} != {{ property.value }}:
+    raise ValueError(f"{{ property.name }} must match const {{ property.value }}, got '{ {{ source }} }'")
+{{ property.python_name }} = cast({{ property.get_type_string() }} , {{ source }})
+{%- endmacro %}
+
+
+{% macro construct(property, source) %}
+_{{ property.python_name }} = {{ source }}
+{% if property.required %}
+{{ construct_impl(property, "_" + property.python_name) }}
+{% else %}
+{{ property.python_name }} : {{ property.get_type_string() }}
+if isinstance(_{{ property.python_name }}, Unset):
+    {{ property.python_name }} = UNSET
+else:
+    {{ construct_impl(property, "_" + property.python_name) | indent }}
+{% endif %}
+{%- endmacro %}


### PR DESCRIPTION
For 'const' properties, the parsed value will now be checked against the value in the schema at runtime and a ValueError will be raised if they do not match. Until now, the values would just be `cast` to a `Literal` without checking.

This helps with with parsing `oneOf` when matching a const property is the only way to resolve which of the types should be returned. i.e. if a `oneOf` contains two schemas, but the properties in one are a subset of the other, then the only way to know which one to return is to validate the `const` value.

I know that for the most part this library parses but doesn't validate, but I don't see a way around it in this case. The spec itself mentions validation when talking about `oneOf`:

```
In OAS 3.0, a response payload MAY be described to be exactly one of any number of types:
[...]
which means the payload MUST, by validation, match exactly one of the schemas described by Cat, Dog, or Lizard.
```

Note that this also addresses some of the use cases for discriminated unions. Per the spec, the `a discriminator MAY act as a "hint" to shortcut validation and selection of the matching schema which may be a costly operation, depending on the complexity of the schema.` so implementing discriminators would be a speedup but with this change we'll at least construct the correct type.

I'm happy to take any feedback, or abandon this if you don't like fact that it is validation. I originally went to try to implement discriminated unions fully, but this seemed like a much easier step towards that that gets the same result.