### PR TITLE
Add literals alongside enums 

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_has_properties_but_no_type_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Literal
 
 
 class AllOfHasPropertiesButNoTypeTypeEnum(IntEnum):
@@ -7,3 +8,9 @@ class AllOfHasPropertiesButNoTypeTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AllOfHasPropertiesButNoTypeTypeEnumLiteral = Literal[
+    0,
+    1,
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/all_of_sub_model_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Literal
 
 
 class AllOfSubModelTypeEnum(IntEnum):
@@ -7,3 +8,9 @@ class AllOfSubModelTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AllOfSubModelTypeEnumLiteral = Literal[
+    0,
+    1,
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_all_of_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_all_of_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class AnAllOfEnum(str, Enum):
@@ -9,3 +10,11 @@ class AnAllOfEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnAllOfEnumLiteral = Literal[
+    "a_default",
+    "bar",
+    "foo",
+    "overridden_default",
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class AnEnum(str, Enum):
@@ -7,3 +8,9 @@ class AnEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnEnumLiteral = Literal[
+    "FIRST_VALUE",
+    "SECOND_VALUE",
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_enum_with_null.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_enum_with_null.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class AnEnumWithNull(str, Enum):
@@ -7,3 +8,9 @@ class AnEnumWithNull(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnEnumWithNullLiteral = Literal[
+    "FIRST_VALUE",
+    "SECOND_VALUE",
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_int_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Literal
 
 
 class AnIntEnum(IntEnum):
@@ -8,3 +9,10 @@ class AnIntEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnIntEnumLiteral = Literal[
+    -1,
+    1,
+    2,
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class AnotherAllOfSubModelType(str, Enum):
@@ -6,3 +7,6 @@ class AnotherAllOfSubModelType(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnotherAllOfSubModelTypeLiteral = Literal["submodel",]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/another_all_of_sub_model_type_enum.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Literal
 
 
 class AnotherAllOfSubModelTypeEnum(IntEnum):
@@ -6,3 +7,6 @@ class AnotherAllOfSubModelTypeEnum(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+AnotherAllOfSubModelTypeEnumLiteral = Literal[0,]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/different_enum.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class DifferentEnum(str, Enum):
@@ -7,3 +8,9 @@ class DifferentEnum(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+DifferentEnumLiteral = Literal[
+    "DIFFERENT",
+    "OTHER",
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_int_enum_header.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_int_enum_header.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from typing import Literal
 
 
 class GetLocationHeaderTypesIntEnumHeader(IntEnum):
@@ -8,3 +9,10 @@ class GetLocationHeaderTypesIntEnumHeader(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+GetLocationHeaderTypesIntEnumHeaderLiteral = Literal[
+    1,
+    2,
+    3,
+]

--- a/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_string_enum_header.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/get_location_header_types_string_enum_header.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 
 class GetLocationHeaderTypesStringEnumHeader(str, Enum):
@@ -8,3 +9,10 @@ class GetLocationHeaderTypesStringEnumHeader(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+GetLocationHeaderTypesStringEnumHeaderLiteral = Literal[
+    "one",
+    "three",
+    "two",
+]

--- a/openapi_python_client/templates/int_enum.py.jinja
+++ b/openapi_python_client/templates/int_enum.py.jinja
@@ -1,3 +1,4 @@
+from typing import Literal
 from enum import IntEnum
 
 class {{ enum.class_info.name }}(IntEnum):
@@ -7,3 +8,10 @@ class {{ enum.class_info.name }}(IntEnum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+{{ enum.class_info.name }}Literal = Literal[
+    {% for _, value in enum.values.items() %}
+    {{ value }},
+    {% endfor %}
+]

--- a/openapi_python_client/templates/int_enum.py.jinja
+++ b/openapi_python_client/templates/int_enum.py.jinja
@@ -1,5 +1,6 @@
-from typing import Literal
 from enum import IntEnum
+from typing import Literal
+
 
 class {{ enum.class_info.name }}(IntEnum):
     {% for key, value in enum.values.items() %}

--- a/openapi_python_client/templates/str_enum.py.jinja
+++ b/openapi_python_client/templates/str_enum.py.jinja
@@ -1,3 +1,4 @@
+from typing import Literal
 from enum import Enum
 
 class {{ enum.class_info.name }}(str, Enum):
@@ -7,3 +8,10 @@ class {{ enum.class_info.name }}(str, Enum):
 
     def __str__(self) -> str:
         return str(self.value)
+
+
+{{ enum.class_info.name }}Literal = Literal[
+    {% for _, value in enum.values|dictsort(true) %}
+    "{{ value }}",
+    {% endfor %}
+]

--- a/openapi_python_client/templates/str_enum.py.jinja
+++ b/openapi_python_client/templates/str_enum.py.jinja
@@ -1,5 +1,6 @@
-from typing import Literal
 from enum import Enum
+from typing import Literal
+
 
 class {{ enum.class_info.name }}(str, Enum):
     {% for key, value in enum.values|dictsort(true) %}


### PR DESCRIPTION
Generating literal types alongside string and int Enums. We really need it in our code so have this in our custom templates. I thought there are others who would like to have it in the default template.

Replaces the [original PR](https://github.com/openapi-generators/openapi-python-client/pull/1016). This PR adds tests.