### PR TITLE
fix class generation for nullable enums

### DIFF
--- a/end_to_end_tests/baseline_openapi_3.0.json
+++ b/end_to_end_tests/baseline_openapi_3.0.json
@@ -1660,7 +1660,9 @@
           "model",
           "nullable_model",
           "one_of_models",
-          "nullable_one_of_models"
+          "nullable_one_of_models",
+          "nullable_enum_as_ref",
+          "nullable_enum_inline"
         ],
         "type": "object",
         "properties": {
@@ -1830,6 +1832,14 @@
               }
             ],
             "nullable": true
+          },
+          "nullable_enum_as_ref": {
+            "$ref": "#/components/schemas/AnEnumWithNull"
+          },
+          "nullable_enum_inline": {
+            "type": "string",
+            "enum": ["FIRST_VALUE", "SECOND_VALUE", null],
+            "nullable": true
           }
         },
         "description": "A Model for testing all the ways custom objects can be used ",
@@ -1850,6 +1860,7 @@
           "SECOND_VALUE",
           null
         ],
+        "nullable": true,
         "description": "For testing Enums with mixed string / null values "
       },
       "AnEnumWithOnlyNull": {

--- a/end_to_end_tests/baseline_openapi_3.1.yaml
+++ b/end_to_end_tests/baseline_openapi_3.1.yaml
@@ -1650,7 +1650,9 @@ info:
         "model",
         "nullable_model",
         "one_of_models",
-        "nullable_one_of_models"
+        "nullable_one_of_models",
+        "nullable_enum_as_ref",
+        "nullable_enum_inline"
       ],
       "type": "object",
       "properties": {
@@ -1840,6 +1842,13 @@ info:
               "$ref": "#/components/schemas/ModelWithUnionProperty"
             }
           ]
+        },
+        "nullable_enum_as_ref": {
+          "$ref": "#/components/schemas/AnEnumWithNull"
+        },
+        "nullable_enum_inline": {
+          "type": ["string", "null"],
+          "enum": ["FIRST_VALUE", "SECOND_VALUE", null]
         }
       },
       "description": "A Model for testing all the ways custom objects can be used ",
@@ -1855,6 +1864,7 @@ info:
     },
     "AnEnumWithNull": {
       "title": "AnEnumWithNull",
+      "type": ["string", "null"],
       "enum": [
         "FIRST_VALUE",
         "SECOND_VALUE",

--- a/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/__init__.py
@@ -4,6 +4,7 @@ from .a_discriminated_union_type_1 import ADiscriminatedUnionType1
 from .a_discriminated_union_type_2 import ADiscriminatedUnionType2
 from .a_form_data import AFormData
 from .a_model import AModel
+from .a_model_nullable_enum_inline import AModelNullableEnumInline
 from .a_model_with_properties_reference_that_are_not_object import AModelWithPropertiesReferenceThatAreNotObject
 from .all_of_has_properties_but_no_type import AllOfHasPropertiesButNoType
 from .all_of_has_properties_but_no_type_type_enum import AllOfHasPropertiesButNoTypeTypeEnum
@@ -91,6 +92,7 @@ __all__ = (
     "AllOfSubModel",
     "AllOfSubModelTypeEnum",
     "AModel",
+    "AModelNullableEnumInline",
     "AModelWithPropertiesReferenceThatAreNotObject",
     "AnAllOfEnum",
     "AnArrayWithACircularRefInItemsObjectAdditionalPropertiesAItem",

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -4,8 +4,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
 from attrs import define as _attrs_define
 from dateutil.parser import isoparse
 
+from ..models.a_model_nullable_enum_inline import AModelNullableEnumInline
 from ..models.an_all_of_enum import AnAllOfEnum
 from ..models.an_enum import AnEnum
+from ..models.an_enum_with_null import AnEnumWithNull
 from ..models.different_enum import DifferentEnum
 from ..types import UNSET, Unset
 
@@ -33,6 +35,8 @@ class AModel:
         nullable_one_of_models (Union['FreeFormModel', 'ModelWithUnionProperty', None]):
         model (ModelWithUnionProperty):
         nullable_model (Union['ModelWithUnionProperty', None]):
+        nullable_enum_as_ref (Union[AnEnumWithNull, None]): For testing Enums with mixed string / null values
+        nullable_enum_inline (Union[AModelNullableEnumInline, None]):
         any_value (Union[Unset, Any]):
         an_optional_allof_enum (Union[Unset, AnAllOfEnum]):
         nested_list_of_enums (Union[Unset, List[List[DifferentEnum]]]):
@@ -57,6 +61,8 @@ class AModel:
     nullable_one_of_models: Union["FreeFormModel", "ModelWithUnionProperty", None]
     model: "ModelWithUnionProperty"
     nullable_model: Union["ModelWithUnionProperty", None]
+    nullable_enum_as_ref: Union[AnEnumWithNull, None]
+    nullable_enum_inline: Union[AModelNullableEnumInline, None]
     an_allof_enum_with_overridden_default: AnAllOfEnum = AnAllOfEnum.OVERRIDDEN_DEFAULT
     any_value: Union[Unset, Any] = UNSET
     an_optional_allof_enum: Union[Unset, AnAllOfEnum] = UNSET
@@ -121,6 +127,18 @@ class AModel:
             nullable_model = self.nullable_model.to_dict()
         else:
             nullable_model = self.nullable_model
+
+        nullable_enum_as_ref: Union[None, str]
+        if isinstance(self.nullable_enum_as_ref, AnEnumWithNull):
+            nullable_enum_as_ref = self.nullable_enum_as_ref.value
+        else:
+            nullable_enum_as_ref = self.nullable_enum_as_ref
+
+        nullable_enum_inline: Union[None, str]
+        if isinstance(self.nullable_enum_inline, AModelNullableEnumInline):
+            nullable_enum_inline = self.nullable_enum_inline.value
+        else:
+            nullable_enum_inline = self.nullable_enum_inline
 
         any_value = self.any_value
 
@@ -199,6 +217,8 @@ class AModel:
                 "nullable_one_of_models": nullable_one_of_models,
                 "model": model,
                 "nullable_model": nullable_model,
+                "nullable_enum_as_ref": nullable_enum_as_ref,
+                "nullable_enum_inline": nullable_enum_inline,
             }
         )
         if any_value is not UNSET:
@@ -342,6 +362,36 @@ class AModel:
 
         nullable_model = _parse_nullable_model(d.pop("nullable_model"))
 
+        def _parse_nullable_enum_as_ref(data: object) -> Union[AnEnumWithNull, None]:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_an_enum_with_null = AnEnumWithNull(data)
+
+                return componentsschemas_an_enum_with_null
+            except:  # noqa: E722
+                pass
+            return cast(Union[AnEnumWithNull, None], data)
+
+        nullable_enum_as_ref = _parse_nullable_enum_as_ref(d.pop("nullable_enum_as_ref"))
+
+        def _parse_nullable_enum_inline(data: object) -> Union[AModelNullableEnumInline, None]:
+            if data is None:
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                nullable_enum_inline = AModelNullableEnumInline(data)
+
+                return nullable_enum_inline
+            except:  # noqa: E722
+                pass
+            return cast(Union[AModelNullableEnumInline, None], data)
+
+        nullable_enum_inline = _parse_nullable_enum_inline(d.pop("nullable_enum_inline"))
+
         any_value = d.pop("any_value", UNSET)
 
         _an_optional_allof_enum = d.pop("an_optional_allof_enum", UNSET)
@@ -469,6 +519,8 @@ class AModel:
             nullable_one_of_models=nullable_one_of_models,
             model=model,
             nullable_model=nullable_model,
+            nullable_enum_as_ref=nullable_enum_as_ref,
+            nullable_enum_inline=nullable_enum_inline,
             any_value=any_value,
             an_optional_allof_enum=an_optional_allof_enum,
             nested_list_of_enums=nested_list_of_enums,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model_nullable_enum_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model_nullable_enum_inline.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class AModelNullableEnumInline(str, Enum):
+    FIRST_VALUE = "FIRST_VALUE"
+    SECOND_VALUE = "SECOND_VALUE"
+
+    def __str__(self) -> str:
+        return str(self.value)


### PR DESCRIPTION
Fixes #1120.

The problem was happening in a pretty specific case which wasn't covered by any existing tests. The preconditions were:
* OpenAPI version is 3.0
* The property has an explicitly declared type
* The property has a list of `enum` values that includes `null` (plus at least one non-null value)
* The property has `nullable: true`

The failure mode was an interaction between three pieces of logic:
* If `EnumProperty.build` sees that the enum allows nulls, it creates a union with `UnionProperty.build`, setting `anyOf` to two types: an EnumProperty.build and a NoneProperty.
* If `UnionProperty.build` sees a list of multiple data types (3.1 style), it treats each of those types as basically equivalent to an `anyOf` item. The intended use case, I think, was if you wrote something like `type: ["string", "null"]`; it was not really meant to apply to cases where you were _also_ using `anyOf`.
* The 3.0-to-3.1 schema transform logic handles `nullable: true` by changing the type to a list of [whatever, null] _if the type was explicitly specified_.

So, with an input like this—
```yaml
    MyNullableEnum:
      type: string
      nullable: true
      enum: ["a", "b"]
```
—it would end up calling `UnionProperty.build` with an `anyOf` list of two types— and a `type` of `["string", "null"]. UnionProperty would treat that as an `anyOf` with _four_ types: string, null, enum, and null. I'm not 100% sure how it got from that to generating three identical classes, but this had already gone astray from what we were trying to do.

My fix works by not using `UnionProperty.build`, but just constructing the UnionProperty directly with the structure that we want. I think this is appropriate because the effect we want isn't really the same as if such a union had been written explicitly; we don't want multiple generated type names, we want to just attach the top-level schema name to the enum part.