### PR TITLE
fix: allow required fields list to be specified as empty (#651)

### DIFF
--- a/openapi_python_client/schema/openapi_schema_pydantic/schema.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/schema.py
@@ -34,7 +34,7 @@ class Schema(BaseModel):
     uniqueItems: Optional[bool] = None
     maxProperties: Optional[int] = Field(default=None, ge=0)
     minProperties: Optional[int] = Field(default=None, ge=0)
-    required: Optional[List[str]] = Field(default=None, min_length=1)
+    required: Optional[List[str]] = Field(default=None)
     enum: Union[None, List[Any]] = Field(default=None, min_length=1)
     const: Union[None, StrictStr, StrictInt, StrictFloat, StrictBool] = None
     type: Union[DataType, List[DataType], None] = Field(default=None)


### PR DESCRIPTION
Resolves #651 

From that issue:

The OpenAPI spec [section](https://swagger.io/specification/) on the `Schema` object says:

> The Schema Object allows the definition of input and output data types. These types can be objects, but also primitives and arrays. This object is a superset of the [JSON Schema Specification Draft 2020-12](https://tools.ietf.org/html/draft-bhutton-json-schema-00).
> 
> For more information about the properties, see [JSON Schema Core](https://tools.ietf.org/html/draft-bhutton-json-schema-00) and [JSON Schema Validation](https://tools.ietf.org/html/draft-bhutton-json-schema-validation-00).

The JSON Schema Validation spec [says](https://json-schema.org/draft/2020-12/json-schema-validation#name-required) of the `required` property:

> The value of this keyword MUST be an array. Elements of this array, if any, MUST be strings, and MUST be unique.
>
> An object instance is valid against this keyword if every item in the array is the name of a property in the instance.
>
> Omitting this keyword has the same behavior as an empty array.

... which makes pretty clear that specifying an empty array for `required` is supported by JSON Schema, and thus by OpenAPI, and thus should be supported by this tool's model of OpenAPI.

