### PR TITLE
add option to use dataclasses instead of attrs in generated code

### DIFF
--- a/.changeset/use_dataclasses.md
+++ b/.changeset/use_dataclasses.md
@@ -1,0 +1,14 @@
+---
+default: minor
+---
+
+# Add `use_dataclasses` config setting
+
+Instead of using the `attrs` package in the generated code, you can choose to use the built-in `dataclasses` module by setting `use_dataclasses: true` in your config file. This may be useful if you are trying to reduce external dependencies, or if your client package might be used in applications that require different versions of `attrs`.
+
+The generated client code should behave exactly the same from an application's point of view except for the following differences:
+
+- The generated project file does not have an `attrs` dependency.
+- If you were using `attrs.evolve` to create an updated instance of a model class, you should use `dataclasses.replace` instead.
+- Undocumented attributes of the `Client` class that had an underscore prefix in their names are no longer available.
+- The builder methods `with_cookies`, `with_headers`, and `with_timeout` do _not_ modify any Httpx client that may have been created from the previous Client instance; they affect only the new instance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you think that some of the added code is not testable (or testing it would ad
 
 This project aims to have all "happy paths" (types of code which _can_ be generated) covered by end to end tests (snapshot tests). In order to check code changes against the previous set of snapshots (called a "golden record" here), you can run `pdm e2e`. To regenerate the snapshots, run `pdm regen`.
 
-There are 4 types of snapshots generated right now, you may have to update only some or all of these depending on the changes you're making. Within the `end_to_end_tets` directory:
+There are 4 types of snapshots generated right now, you may have to update only some or all of these depending on the changes you're making. Within the `end_to_end_tests` directory:
 
 1. `baseline_openapi_3.0.json` creates `golden-record` for testing OpenAPI 3.0 features
 2. `baseline_openapi_3.1.yaml` is checked against `golden-record` for testing OpenAPI 3.1 features (and ensuring consistency with 3.0)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ post_hooks:
    - "ruff format ."
 ```
 
+### use_dataclasses
+
+By default, `openapi-python-client` uses the `attrs` package when generating model classes (and the `Client` class). Setting `use_dataclasses` to `true` causes it to use the built-in `dataclasses` module instead. This may be useful if you are trying to reduce external dependencies, or if your client package might be used in applications that require different versions of `attrs`.
+
+The generated client code should behave exactly the same from an application's point of view except for the following differences:
+
+- The generated project file does not have an `attrs` dependency.
+- If you were using `attrs.evolve` to create an updated instance of a model class, you should use `dataclasses.replace` instead.
+- Undocumented attributes of the `Client` class that had an underscore prefix in their names are no longer available.
+- The builder methods `with_cookies`, `with_headers`, and `with_timeout` do _not_ modify any Httpx client that may have been created from the previous Client instance; they affect only the new instance.
+
 ### use_path_prefixes_for_title_model_names
 
 By default, `openapi-python-client` generates class names which include the full path to the schema, including any parent-types. This can result in very long class names like `MyRouteSomeClassAnotherClassResponse`—which is very unique and unlikely to cause conflicts with future API additions, but also super verbose.

--- a/end_to_end_tests/config_dataclasses.yml
+++ b/end_to_end_tests/config_dataclasses.yml
@@ -1,0 +1,1 @@
+use_dataclasses: true

--- a/end_to_end_tests/golden-record-dataclasses/.gitignore
+++ b/end_to_end_tests/golden-record-dataclasses/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/end_to_end_tests/golden-record-dataclasses/README.md
+++ b/end_to_end_tests/golden-record-dataclasses/README.md
@@ -1,0 +1,124 @@
+# my-dataclasses-api-client
+A client library for accessing My Dataclasses API
+
+## Usage
+First, create a client:
+
+```python
+from my_dataclasses_api_client import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from my_dataclasses_api_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from my_dataclasses_api_client.models import MyDataModel
+from my_dataclasses_api_client.api.my_tag import get_my_data_model
+from my_dataclasses_api_client.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from my_dataclasses_api_client.models import MyDataModel
+from my_dataclasses_api_client.api.my_tag import get_my_data_model
+from my_dataclasses_api_client.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `my_dataclasses_api_client.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from my_dataclasses_api_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from my_dataclasses_api_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+
+## Building / publishing this package
+This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:
+1. Update the metadata in pyproject.toml (e.g. authors, version)
+1. If you're using a private repository, configure it with Poetry
+    1. `poetry config repositories.<your-repository-name> <url-to-your-repository>`
+    1. `poetry config http-basic.<your-repository-name> <username> <password>`
+1. Publish the client with `poetry publish --build -r <your-repository-name>` or, if for public PyPI, just `poetry publish --build`
+
+If you want to install this client into another project without publishing it (e.g. for development) then:
+1. If that project **is using Poetry**, you can simply do `poetry add <path-to-this-client>` from that project
+1. If that project is not using Poetry:
+    1. Build a wheel with `poetry build -f wheel`
+    1. Install that wheel from the other project `pip install <path-to-wheel>`

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/__init__.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing My Dataclasses API"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/api/__init__.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/client.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/client.py
@@ -1,0 +1,270 @@
+import copy
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+@dataclass
+class _HttpxConfig:
+    cookies: Dict[str, str] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=dict)
+    timeout: Optional[httpx.Timeout] = None
+    verify_ssl: bool = True
+    follow_redirects: bool = False
+    httpx_args: Dict[str, str] = field(default_factory=dict)
+
+
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    _base_url: str
+    raise_on_unexpected_status: bool
+    _httpx_config: _HttpxConfig
+
+    def __init__(
+        self,
+        base_url: str,
+        cookies: Dict[str, str] = {},
+        headers: Dict[str, str] = {},
+        timeout: Optional[httpx.Timeout] = None,
+        verify_ssl: bool = True,
+        follow_redirects: bool = False,
+        httpx_args: Dict[str, Any] = {},
+        raise_on_unexpected_status: bool = False,
+    ) -> None:
+        self.raise_on_unexpected_status = raise_on_unexpected_status
+        self._base_url = base_url
+        self._httpx_config = _HttpxConfig(cookies, headers, timeout, verify_ssl, follow_redirects, httpx_args)
+
+    def _with_httpx_config(self, httpx_config: _HttpxConfig) -> "Client":
+        ret = copy.copy(self)
+        ret._httpx_config = httpx_config
+        return ret
+
+    def with_headers(self, headers: Dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, headers={**self._httpx_config.headers, **headers}),
+        )
+
+    def with_cookies(self, cookies: Dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, cookies={**self._httpx_config.cookies, **cookies}),
+        )
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        return self._with_httpx_config(replace(self._httpx_config, timeout=timeout))
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._httpx_config.cookies,
+                headers=self._httpx_config.headers,
+                timeout=self._httpx_config.timeout,
+                verify=self._httpx_config.verify_ssl,
+                follow_redirects=self._httpx_config.follow_redirects,
+                **self._httpx_config.httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._httpx_config.base_url,
+                cookies=self._httpx_config.cookies,
+                headers=self._httpx_config.headers,
+                timeout=self._httpx_config.timeout,
+                verify=self._httpx_config.verify_ssl,
+                follow_redirects=self._httpx_config.follow_redirects,
+                **self._httpx_config.httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    _base_url: str
+    raise_on_unexpected_status: bool
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+    _httpx_config: _HttpxConfig
+
+    def _with_httpx_config(self, httpx_config: _HttpxConfig) -> "AuthenticatedClient":
+        ret = copy.copy(self)
+        ret._httpx_config = httpx_config
+        return ret
+
+    def with_headers(self, headers: Dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, headers={**self._httpx_config.headers, **headers}),
+        )
+
+    def with_cookies(self, cookies: Dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, cookies={**self._httpx_config.cookies, **cookies}),
+        )
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        return self._with_httpx_config(replace(self._httpx_config, timeout=timeout))
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._httpx_config.cookies,
+                headers=self._httpx_config.headers,
+                timeout=self._httpx_config.timeout,
+                verify=self._httpx_config.verify_ssl,
+                follow_redirects=self._httpx_config.follow_redirects,
+                **self._httpx_config.httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._httpx_config.base_url,
+                cookies=self._httpx_config.cookies,
+                headers=self._httpx_config.headers,
+                timeout=self._httpx_config.timeout,
+                verify=self._httpx_config.verify_ssl,
+                follow_redirects=self._httpx_config.follow_redirects,
+                **self._httpx_config.httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/errors.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/models/__init__.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/models/__init__.py
@@ -1,0 +1,5 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .a_model import AModel
+
+__all__ = ("AModel",)

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/models/a_model.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass as _dataclass
+from dataclasses import field as _dataclasses_field
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AModel")
+
+
+@_dataclass
+class AModel:
+    """
+    Attributes:
+        required_string (str):
+        optional_string (Union[Unset, str]):
+        string_with_default (Union[Unset, str]):  Default: 'abc'.
+    """
+
+    required_string: str
+    optional_string: Union[Unset, str] = UNSET
+    string_with_default: Union[Unset, str] = "abc"
+    additional_properties: Dict[str, Any] = _dataclasses_field(init=False, default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        required_string = self.required_string
+
+        optional_string = self.optional_string
+
+        string_with_default = self.string_with_default
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "requiredString": required_string,
+            }
+        )
+        if optional_string is not UNSET:
+            field_dict["optionalString"] = optional_string
+        if string_with_default is not UNSET:
+            field_dict["stringWithDefault"] = string_with_default
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        required_string = d.pop("requiredString")
+
+        optional_string = d.pop("optionalString", UNSET)
+
+        string_with_default = d.pop("stringWithDefault", UNSET)
+
+        a_model = cls(
+            required_string=required_string,
+            optional_string=optional_string,
+            string_with_default=string_with_default,
+        )
+
+        a_model.additional_properties = d
+        return a_model
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/py.typed
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/types.py
+++ b/end_to_end_tests/golden-record-dataclasses/my_dataclasses_api_client/types.py
@@ -1,0 +1,45 @@
+"""Contains some shared types for properties"""
+
+from http import HTTPStatus
+from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+FileJsonType = Tuple[Optional[str], BinaryIO, Optional[str]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileJsonType:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["File", "Response", "FileJsonType", "Unset", "UNSET"]

--- a/end_to_end_tests/golden-record-dataclasses/pyproject.toml
+++ b/end_to_end_tests/golden-record-dataclasses/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "my-dataclasses-api-client"
+version = "0.1.0"
+description = "A client library for accessing My Dataclasses API"
+authors = []
+readme = "README.md"
+packages = [
+    {include = "my_dataclasses_api_client"},
+]
+include = ["CHANGELOG.md", "my_dataclasses_api_client/py.typed"]
+
+
+[tool.poetry.dependencies]
+python = "^3.8"
+httpx = ">=0.20.0,<0.28.0"
+python-dateutil = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]

--- a/end_to_end_tests/openapi_3.1_dataclasses.yaml
+++ b/end_to_end_tests/openapi_3.1_dataclasses.yaml
@@ -1,0 +1,20 @@
+openapi: 3.1.0
+info:
+  title: My Dataclasses API
+  description: An API for testing dataclasses in openapi-python-client
+  version: 0.1.0
+paths: {}
+components:
+  schemas:
+    AModel:
+      type: object
+      properties:
+        optionalString:
+          type: string
+        requiredString:
+          type: string
+        stringWithDefault:
+          type: string
+          default: abc
+      required:
+        - requiredString

--- a/end_to_end_tests/regen_golden_record.py
+++ b/end_to_end_tests/regen_golden_record.py
@@ -51,6 +51,26 @@ def regen_golden_record_3_1_features():
     output_path.rename(gr_path)
 
 
+def regen_dataclasses_golden_record():
+    runner = CliRunner()
+    openapi_path = Path(__file__).parent / "openapi_3.1_dataclasses.yaml"
+
+    gr_path = Path(__file__).parent / "golden-record-dataclasses"
+    output_path = Path.cwd() / "my-dataclasses-api-client"
+    config_path = Path(__file__).parent / "config_dataclasses.yml"
+
+    shutil.rmtree(gr_path, ignore_errors=True)
+    shutil.rmtree(output_path, ignore_errors=True)
+
+    result = runner.invoke(app, ["generate", f"--path={openapi_path}", f"--config={config_path}"])
+
+    if result.stdout:
+        print(result.stdout)
+    if result.exception:
+        raise result.exception
+    output_path.rename(gr_path)
+
+
 def regen_literal_enums_golden_record():
     runner = CliRunner()
     openapi_path = Path(__file__).parent / "openapi_3.1_enums.yaml"
@@ -144,4 +164,5 @@ if __name__ == "__main__":
     regen_golden_record_3_1_features()
     regen_metadata_snapshots()
     regen_custom_template_golden_record()
+    regen_dataclasses_golden_record()
     regen_literal_enums_golden_record()

--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -89,6 +89,7 @@ class Project:
 
         self.env.filters.update(TEMPLATE_FILTERS)
         self.env.globals.update(
+            config=config,
             utils=utils,
             python_identifier=lambda x: utils.PythonIdentifier(x, config.field_prefix),
             class_name=lambda x: utils.ClassName(x, config.field_prefix),

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -39,6 +39,7 @@ class ConfigFile(BaseModel):
     project_name_override: Optional[str] = None
     package_name_override: Optional[str] = None
     package_version_override: Optional[str] = None
+    use_dataclasses: bool = False
     use_path_prefixes_for_title_model_names: bool = True
     post_hooks: Optional[List[str]] = None
     field_prefix: str = "field_"
@@ -67,6 +68,7 @@ class Config:
     project_name_override: Optional[str]
     package_name_override: Optional[str]
     package_version_override: Optional[str]
+    use_dataclasses: bool
     use_path_prefixes_for_title_model_names: bool
     post_hooks: List[str]
     field_prefix: str
@@ -107,6 +109,7 @@ class Config:
             project_name_override=config_file.project_name_override,
             package_name_override=config_file.package_name_override,
             package_version_override=config_file.package_version_override,
+            use_dataclasses=config_file.use_dataclasses,
             use_path_prefixes_for_title_model_names=config_file.use_path_prefixes_for_title_model_names,
             post_hooks=post_hooks,
             field_prefix=config_file.field_prefix,

--- a/openapi_python_client/templates/client.py.jinja
+++ b/openapi_python_client/templates/client.py.jinja
@@ -4,10 +4,12 @@ from typing import Any, Dict, Union, Optional
 import httpx
 
 {% if config.use_dataclasses %}
-import copy
+from copy import copy
 from dataclasses import dataclass, field, replace
+{% set class_header = "" %}
 {% else %}
 from attrs import define, field, evolve
+{% set class_header = "@define" %}
 {% endif %}
 
 {% if config.use_dataclasses %}
@@ -19,27 +21,13 @@ class _HttpxConfig:
     verify_ssl: bool = True
     follow_redirects: bool = False
     httpx_args: Dict[str, str] = field(default_factory=dict)
-
-{% macro init_args() %}
-        self,
-        base_url: str,
-        cookies: Dict[str, str] = {},
-        headers: Dict[str, str] = {},
-        timeout: Optional[httpx.Timeout] = None,
-        verify_ssl: bool = True,
-        follow_redirects: bool = False,
-        httpx_args: Dict[str, Any] = {},
-        raise_on_unexpected_status: bool = False,
-{% endmacro %}
 {% endif %}
 
 {% macro httpx_client_arg(name) -%}
 {% if config.use_dataclasses %}self._httpx_config.{{ name }}{% else %}self._{{ name }}{% endif %}
 {%- endmacro %}
 
-{% if not config.use_dataclasses %}
-@define
-{% endif %}
+{{ class_header }}
 class Client:
     """A class for keeping track of data related to the API
 
@@ -72,11 +60,12 @@ class Client:
 {% macro attributes(extra_attrs = []) %}
 {% if config.use_dataclasses %}
     _base_url: str
-    raise_on_unexpected_status: bool
 {% for extra in extra_attrs %}
     {{ extra }}
 {% endfor %}
     _httpx_config: _HttpxConfig
+    _client: Optional[httpx.Client]
+    _async_client: Optional[httpx.AsyncClient]
 {% else %}
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
@@ -95,49 +84,61 @@ class Client:
 {% endfor %}
 {% endif %}
 {% endif %}
-{% endmacro %}{{ attributes() }}
+{% endmacro %}
 
-{% if config.use_dataclasses %}
+{{ attributes() }}
+
+{% macro explicit_initializer(extra_attrs = []) %}
     def __init__(
-        {{ init_args() }}
+        self,
+        base_url: str,
+{% for attr in extra_attrs %}
+        {{ attr }},
+{% endfor %}
+        cookies: Dict[str, str] = {},
+        headers: Dict[str, str] = {},
+        timeout: Optional[httpx.Timeout] = None,
+        verify_ssl: bool = True,
+        follow_redirects: bool = False,
+        httpx_args: Dict[str, Any] = {},
+        raise_on_unexpected_status: bool = False,
     ) -> None:
         self.raise_on_unexpected_status = raise_on_unexpected_status
         self._base_url = base_url
         self._httpx_config = _HttpxConfig(
             cookies, headers, timeout, verify_ssl, follow_redirects, httpx_args
         )
+        self._client = None
+        self._async_client = None
+{% endmacro %}
+
+{% if config.use_dataclasses %}
+{{ explicit_initializer() }}
 {% endif %}
 
 {% macro builders(self) %}
 {% if config.use_dataclasses %}
     def _with_httpx_config(self, httpx_config: _HttpxConfig) -> "{{ self }}":
-        ret = copy.copy(self)
+        ret = copy(self)
         ret._httpx_config = httpx_config
+        ret._client = None
+        ret._async_client = None
         return ret
+{% endif %}
 
-    def with_headers(self, headers: Dict[str, str]) -> "{{ self }}":
-        """Get a new client matching this one with additional headers"""
-        return self._with_httpx_config(
-            replace(self._httpx_config, headers={**self._httpx_config.headers, **headers}),
-        )
-
-    def with_cookies(self, cookies: Dict[str, str]) -> "{{ self }}":
-        """Get a new client matching this one with additional cookies"""
-        return self._with_httpx_config(
-            replace(self._httpx_config, cookies={**self._httpx_config.cookies, **cookies}),
-        )
-
-    def with_timeout(self, timeout: httpx.Timeout) -> "{{ self }}":
-        """Get a new client matching this one with a new timeout (in seconds)"""
-        return self._with_httpx_config(replace(self._httpx_config, timeout=timeout))
-{% else %}
     def with_headers(self, headers: Dict[str, str]) -> "{{ self }}":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
             self._client.headers.update(headers)
         if self._async_client is not None:
             self._async_client.headers.update(headers)
+        {% if config.use_dataclasses %}
+        return self._with_httpx_config(
+            replace(self._httpx_config, headers={**self._httpx_config.headers, **headers}),
+        )
+        {% else %}
         return evolve(self, headers={**self._headers, **headers})
+        {% endif %}
 
     def with_cookies(self, cookies: Dict[str, str]) -> "{{ self }}":
         """Get a new client matching this one with additional cookies"""
@@ -145,7 +146,13 @@ class Client:
             self._client.cookies.update(cookies)
         if self._async_client is not None:
             self._async_client.cookies.update(cookies)
+        {% if config.use_dataclasses %}
+        return self._with_httpx_config(
+            replace(self._httpx_config, cookies={**self._httpx_config.cookies, **cookies}),
+        )
+        {% else %}
         return evolve(self, cookies={**self._cookies, **cookies})
+        {% endif %}
 
     def with_timeout(self, timeout: httpx.Timeout) -> "{{ self }}":
         """Get a new client matching this one with a new timeout (in seconds)"""
@@ -153,11 +160,16 @@ class Client:
             self._client.timeout = timeout
         if self._async_client is not None:
             self._async_client.timeout = timeout
+        {% if config.use_dataclasses %}
+        return self._with_httpx_config(replace(self._httpx_config, timeout=timeout))
+        {% else %}
         return evolve(self, timeout=timeout)
-{% endif %}
-{% endmacro %}{{ builders("Client") }}
+        {% endif %}
+{% endmacro %}
 
-{% macro httpx_stuff(name, custom_constructor=None) %}
+{{ builders("Client") }}
+
+{% macro httpx_stuff(name, headers_expr, update_headers=None) %}
     def set_httpx_client(self, client: httpx.Client) -> "{{ name }}":
         """Manually set the underlying httpx.Client
 
@@ -169,13 +181,13 @@ class Client:
     def get_httpx_client(self) -> httpx.Client:
         """Get the underlying httpx.Client, constructing a new one if not previously set"""
         if self._client is None:
-        {% if custom_constructor %}
-            {{ custom_constructor | indent(12) }}
+        {% if update_headers %}
+            {{ update_headers | indent(12) }}
         {% endif %}
             self._client = httpx.Client(
                 base_url=self._base_url,
                 cookies={{ httpx_client_arg("cookies") }},
-                headers={{ httpx_client_arg("headers") }},
+                headers={{ headers_expr }},
                 timeout={{ httpx_client_arg("timeout") }},
                 verify={{ httpx_client_arg("verify_ssl") }},
                 follow_redirects={{ httpx_client_arg("follow_redirects") }},
@@ -203,13 +215,13 @@ class Client:
     def get_async_httpx_client(self) -> httpx.AsyncClient:
         """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
         if self._async_client is None:
-        {% if custom_constructor %}
-            {{ custom_constructor | indent(12) }}
+        {% if update_headers %}
+            {{ update_headers | indent(12) }}
         {% endif %}
             self._async_client = httpx.AsyncClient(
                 base_url={{ httpx_client_arg("base_url") }},
                 cookies={{ httpx_client_arg("cookies") }},
-                headers={{ httpx_client_arg("headers") }},
+                headers={{ headers_expr or httpx_client_arg("headers") }},
                 timeout={{ httpx_client_arg("timeout") }},
                 verify={{ httpx_client_arg("verify_ssl") }},
                 follow_redirects={{ httpx_client_arg("follow_redirects") }},
@@ -225,11 +237,15 @@ class Client:
     async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
         """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)
-{% endmacro %}{{ httpx_stuff("Client") }}
+{% endmacro %}
 
-{% if not config.use_dataclasses %}
-@define
+{% if config.use_dataclasses %}
+{{ httpx_stuff("Client", headers_expr="self._httpx_config.headers") }}
+{% else %}
+{{ httpx_stuff("Client", headers_expr="self._headers") }}
 {% endif %}
+
+{{ class_header }}
 class AuthenticatedClient:
     """A Client which has been authenticated for use on secured endpoints
 
@@ -244,7 +260,29 @@ class AuthenticatedClient:
         auth_header_name: The name of the Authorization header
     """
 
-{{ attributes(["token: str", 'prefix: str = "Bearer"', 'auth_header_name: str = "Authorization"']) }}
+{% set extra_auth_client_args = ["token: str", 'prefix: str = "Bearer"', 'auth_header_name: str = "Authorization"'] %}
+{{ attributes(extra_auth_client_args) }}
+
+{% if config.use_dataclasses %}
+{{ explicit_initializer(extra_auth_client_args) }}
+        self.token = token
+        self.prefix = prefix
+        self.auth_header_name = auth_header_name
+{% endif %}
 
 {{ builders("AuthenticatedClient") }}
-{{ httpx_stuff("AuthenticatedClient", "self._headers[self.auth_header_name] = f\"{self.prefix} {self.token}\" if self.prefix else self.token") }}
+{% set token_string_expr %} f"{self.prefix} {self.token}" if self.prefix else self.token {% endset %}
+{% if config.use_dataclasses %}
+{% set headers_expr %} { self.auth_header_name: ({{ token_string_expr }}), **self._httpx_config.headers } {% endset %}
+{{ httpx_stuff(
+     "AuthenticatedClient",
+     headers_expr=headers_expr,
+) }}
+{% else %}
+{% set update_headers %}self._headers[self.auth_header_name] = {{ token_string_expr }}{% endset %}
+{{ httpx_stuff(
+     "AuthenticatedClient",
+     headers_expr="self._headers",
+     update_headers=update_headers,
+) }}
+{% endif %}

--- a/openapi_python_client/templates/client.py.jinja
+++ b/openapi_python_client/templates/client.py.jinja
@@ -1,11 +1,45 @@
 import ssl
 from typing import Any, Dict, Union, Optional
 
-from attrs import define, field, evolve
 import httpx
 
+{% if config.use_dataclasses %}
+import copy
+from dataclasses import dataclass, field, replace
+{% else %}
+from attrs import define, field, evolve
+{% endif %}
 
+{% if config.use_dataclasses %}
+@dataclass
+class _HttpxConfig:
+    cookies: Dict[str, str] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=dict)
+    timeout: Optional[httpx.Timeout] = None
+    verify_ssl: bool = True
+    follow_redirects: bool = False
+    httpx_args: Dict[str, str] = field(default_factory=dict)
+
+{% macro init_args() %}
+        self,
+        base_url: str,
+        cookies: Dict[str, str] = {},
+        headers: Dict[str, str] = {},
+        timeout: Optional[httpx.Timeout] = None,
+        verify_ssl: bool = True,
+        follow_redirects: bool = False,
+        httpx_args: Dict[str, Any] = {},
+        raise_on_unexpected_status: bool = False,
+{% endmacro %}
+{% endif %}
+
+{% macro httpx_client_arg(name) -%}
+{% if config.use_dataclasses %}self._httpx_config.{{ name }}{% else %}self._{{ name }}{% endif %}
+{%- endmacro %}
+
+{% if not config.use_dataclasses %}
 @define
+{% endif %}
 class Client:
     """A class for keeping track of data related to the API
 
@@ -35,7 +69,15 @@ class Client:
             status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
             argument to the constructor.
     """
-{% macro attributes() %}
+{% macro attributes(extra_attrs = []) %}
+{% if config.use_dataclasses %}
+    _base_url: str
+    raise_on_unexpected_status: bool
+{% for extra in extra_attrs %}
+    {{ extra }}
+{% endfor %}
+    _httpx_config: _HttpxConfig
+{% else %}
     raise_on_unexpected_status: bool = field(default=False, kw_only=True)
     _base_url: str = field(alias="base_url")
     _cookies: Dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
@@ -46,8 +88,49 @@ class Client:
     _httpx_args: Dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
     _client: Optional[httpx.Client] = field(default=None, init=False)
     _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+{% if extra_attrs %}
+{% for extra in extra_attrs %}
+    {{ extra }}
+{% endfor %}
+{% endif %}
+{% endif %}
 {% endmacro %}{{ attributes() }}
+
+{% if config.use_dataclasses %}
+    def __init__(
+        {{ init_args() }}
+    ) -> None:
+        self.raise_on_unexpected_status = raise_on_unexpected_status
+        self._base_url = base_url
+        self._httpx_config = _HttpxConfig(
+            cookies, headers, timeout, verify_ssl, follow_redirects, httpx_args
+        )
+{% endif %}
+
 {% macro builders(self) %}
+{% if config.use_dataclasses %}
+    def _with_httpx_config(self, httpx_config: _HttpxConfig) -> "{{ self }}":
+        ret = copy.copy(self)
+        ret._httpx_config = httpx_config
+        return ret
+
+    def with_headers(self, headers: Dict[str, str]) -> "{{ self }}":
+        """Get a new client matching this one with additional headers"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, headers={**self._httpx_config.headers, **headers}),
+        )
+
+    def with_cookies(self, cookies: Dict[str, str]) -> "{{ self }}":
+        """Get a new client matching this one with additional cookies"""
+        return self._with_httpx_config(
+            replace(self._httpx_config, cookies={**self._httpx_config.cookies, **cookies}),
+        )
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "{{ self }}":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        return self._with_httpx_config(replace(self._httpx_config, timeout=timeout))
+{% else %}
     def with_headers(self, headers: Dict[str, str]) -> "{{ self }}":
         """Get a new client matching this one with additional headers"""
         if self._client is not None:
@@ -71,7 +154,9 @@ class Client:
         if self._async_client is not None:
             self._async_client.timeout = timeout
         return evolve(self, timeout=timeout)
+{% endif %}
 {% endmacro %}{{ builders("Client") }}
+
 {% macro httpx_stuff(name, custom_constructor=None) %}
     def set_httpx_client(self, client: httpx.Client) -> "{{ name }}":
         """Manually set the underlying httpx.Client
@@ -89,12 +174,12 @@ class Client:
         {% endif %}
             self._client = httpx.Client(
                 base_url=self._base_url,
-                cookies=self._cookies,
-                headers=self._headers,
-                timeout=self._timeout,
-                verify=self._verify_ssl,
-                follow_redirects=self._follow_redirects,
-                **self._httpx_args,
+                cookies={{ httpx_client_arg("cookies") }},
+                headers={{ httpx_client_arg("headers") }},
+                timeout={{ httpx_client_arg("timeout") }},
+                verify={{ httpx_client_arg("verify_ssl") }},
+                follow_redirects={{ httpx_client_arg("follow_redirects") }},
+                **{{ httpx_client_arg("httpx_args") }},
             )
         return self._client
 
@@ -122,13 +207,13 @@ class Client:
             {{ custom_constructor | indent(12) }}
         {% endif %}
             self._async_client = httpx.AsyncClient(
-                base_url=self._base_url,
-                cookies=self._cookies,
-                headers=self._headers,
-                timeout=self._timeout,
-                verify=self._verify_ssl,
-                follow_redirects=self._follow_redirects,
-                **self._httpx_args,
+                base_url={{ httpx_client_arg("base_url") }},
+                cookies={{ httpx_client_arg("cookies") }},
+                headers={{ httpx_client_arg("headers") }},
+                timeout={{ httpx_client_arg("timeout") }},
+                verify={{ httpx_client_arg("verify_ssl") }},
+                follow_redirects={{ httpx_client_arg("follow_redirects") }},
+                **{{ httpx_client_arg("httpx_args") }},
             )
         return self._async_client
 
@@ -142,7 +227,9 @@ class Client:
         await self.get_async_httpx_client().__aexit__(*args, **kwargs)
 {% endmacro %}{{ httpx_stuff("Client") }}
 
+{% if not config.use_dataclasses %}
 @define
+{% endif %}
 class AuthenticatedClient:
     """A Client which has been authenticated for use on secured endpoints
 
@@ -157,10 +244,7 @@ class AuthenticatedClient:
         auth_header_name: The name of the Authorization header
     """
 
-{{ attributes() }}
-    token: str
-    prefix: str = "Bearer"
-    auth_header_name: str = "Authorization"
+{{ attributes(["token: str", 'prefix: str = "Bearer"', 'auth_header_name: str = "Authorization"']) }}
 
 {{ builders("AuthenticatedClient") }}
 {{ httpx_stuff("AuthenticatedClient", "self._headers[self.auth_header_name] = f\"{self.prefix} {self.token}\" if self.prefix else self.token") }}

--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -5,8 +5,12 @@ from typing import List
 
 {% endif %}
 
-from attrs import define as _attrs_define
-from attrs import field as _attrs_field
+{% if config.use_dataclasses %}
+from dataclasses import dataclass as _dataclass, field as _dataclasses_field
+{% else %}
+from attrs import define as _attrs_define, field as _attrs_field
+{% endif %}
+
 {% if model.is_multipart_body %}
 import json
 {% endif %}
@@ -59,7 +63,11 @@ T = TypeVar("T", bound="{{ class_name }}")
     {% endfor %}{% endif %}
 {% endmacro %}
 
+{% if config.use_dataclasses %}
+@_dataclass
+{% else %}
 @_attrs_define
+{% endif %}
 class {{ class_name }}:
     {{ safe_docstring(class_docstring_content(model)) | indent(4) }}
 
@@ -74,7 +82,11 @@ class {{ class_name }}:
     {% endif %}
     {% endfor %}
     {% if model.additional_properties %}
+    {% if config.use_dataclasses %}
+    additional_properties: Dict[str, {{ additional_property_type }}] = _dataclasses_field(init=False, default_factory=dict)
+    {% else %}
     additional_properties: Dict[str, {{ additional_property_type }}] = _attrs_field(init=False, factory=dict)
+    {% endif %}
     {% endif %}
 
 {% macro _to_dict(multipart=False) %}

--- a/openapi_python_client/templates/pyproject.toml.jinja
+++ b/openapi_python_client/templates/pyproject.toml.jinja
@@ -20,7 +20,9 @@ include = ["CHANGELOG.md", "{{ package_name }}/py.typed"]
 {% if pdm %}
 dependencies = [
     "httpx>=0.20.0,<0.28.0",
+{% if not config.use_dataclasses %}
     "attrs>=21.3.0",
+{% endif %}
     "python-dateutil>=2.8.0",
 ]
 
@@ -32,7 +34,9 @@ distribution = true
 [tool.poetry.dependencies]
 python = "^3.8"
 httpx = ">=0.20.0,<0.28.0"
+{% if not config.use_dataclasses -%}
 attrs = ">=21.3.0"
+{% endif %}
 python-dateutil = "^2.8.0"
 {% endif %}
 


### PR DESCRIPTION
The last time this idea came up (https://github.com/openapi-generators/openapi-python-client/issues/743), @dbanty felt that there wasn't a compelling reason to switch from `attrs`. I decided anyway to see how much of a lift it would be— in the generated code, that is, not in the generator. A few reasons:

1. In my main use case, which is creating a library to be used by all sorts of third-party applications, there's an incentive to minimize external dependencies if possible.
2. Even though `attrs` is very popular, I think it's likely to become somewhat less of a standard as Python's dataclasses module keeps on copying features from it.
3. It's true that `attrs` has some features that `dataclasses` doesn't, but we're not really using those features anyway in the generated code (with one exception that I'll mention below). Mostly we're just using the simplest possible attribute declaration pattern in model classes.

As I expected, implementing this for the model classes was pretty simple. The only other place we were using `attrs` in the generated code was in the `Client` and `AuthenticatedClient` classes, and there things got trickier.

In those classes, we were taking advantage of `attrs`'s `alias` option in order to define underscored attributes that the app isn't meant to access directly, but that can still be set by name without the underscore in the initializer. You can't do that with dataclasses. However, since the app isn't meant to access them directly, I felt freer to change things there... and attrs/dataclass-type behavior is not really inherent to what the client classes are for, from the app's point of view, it's just an implementation detail.

So, in `use_dataclasses` mode, I changed the clients to plain Python classes with no attrs/dataclass decorators—and moved those Httpx-related attributes into a separate dataclass, so we could still take advantage of copy-and-set behavior for builder methods. That is a fairly different implementation and code structure, which makes the Jinja template a bit hairy, but you can see what it ends up looking like [here](https://github.com/openapi-generators/openapi-python-client/pull/1158/files#diff-5c67f783f0b460ad7a12bdbff2deafa7d485188886cb30148221bd00576c9a4c). However, when you're _not_ in `use_dataclasses` mode, the implementation does not change at all (you can see there are no changes to existing code in `golden_record`), so I believe this is not a breaking change.

(We _could_ decide to unify those implementations by backporting those changes to the not-using-dataclasses mode, so the only differences between the two would be the decorator names. I do think that'd be a little bit cleaner— the Httpx options do all go together, and I don't think there's a compelling reason to have them be separate attributes on the client class. And, again, apps were never meant to access those directly... but in Python, we couldn't prevent that, so that _could_ be considered a breaking change depending on your standards for what is a public/supported interface.)