### PR TITLE
Avoid duplicating user-defined enum property names

### DIFF
--- a/openapi_python_client/parser/properties/enum_property.py
+++ b/openapi_python_client/parser/properties/enum_property.py
@@ -120,6 +120,11 @@ class EnumProperty(PropertyProtocol):
         class_name = data.title or name
         if parent_name:
             class_name = f"{utils.pascal_case(parent_name)}{utils.pascal_case(class_name)}"
+            original_class_name = class_name
+            name_index = 0
+            while class_name in schemas.classes_by_name:
+                name_index += 1
+                class_name = f"{original_class_name}PropertyEnum_{name_index}"
         class_info = Class.from_string(string=class_name, config=config)
         values = EnumProperty.values_from_list(value_list, class_info)
 

--- a/openapi_python_client/parser/properties/literal_enum_property.py
+++ b/openapi_python_client/parser/properties/literal_enum_property.py
@@ -119,6 +119,11 @@ class LiteralEnumProperty(PropertyProtocol):
         class_name = data.title or name
         if parent_name:
             class_name = f"{utils.pascal_case(parent_name)}{utils.pascal_case(class_name)}"
+            original_class_name = class_name
+            name_index = 0
+            while class_name in schemas.classes_by_name:
+                name_index += 1
+                class_name = f"{original_class_name}PropertyEnum_{name_index}"
         class_info = Class.from_string(string=class_name, config=config)
         values: set[str | int] = set(value_list)
 

--- a/tests/test_parser/test_properties/test_enum_property.py
+++ b/tests/test_parser/test_properties/test_enum_property.py
@@ -35,6 +35,34 @@ def test_conflict(config: Config, property_class: PropertyClass) -> None:
     assert err.detail == "Found conflicting enums named Existing with incompatible values."
 
 
+def test_avoids_false_conflict(config: Config, property_class: PropertyClass) -> None:
+    schemas = Schemas()
+
+    _, schemas = property_class.build(
+        data=oai.Schema(enum=["a"]), name="Friend", required=True, schemas=schemas, parent_name="", config=config
+    )
+    asdf, schemas = property_class.build(
+        data=oai.Schema(enum=["a", "b"]),
+        name="FriendShips",
+        required=True,
+        schemas=schemas,
+        parent_name="",
+        config=config,
+    )
+    prop, new_schemas = property_class.build(
+        data=oai.Schema(enum=["c"]),
+        name="ships",
+        required=True,
+        schemas=schemas,
+        parent_name="Friend",
+        config=config,
+    )
+
+    assert sorted([n for n in schemas.classes_by_name]) == ["Friend", "FriendShips"]
+    assert sorted([n for n in new_schemas.classes_by_name]) == ["Friend", "FriendShips", "FriendShipsPropertyEnum1"]
+    assert prop.name == "ships"
+
+
 def test_bad_default_value(config: Config, property_class: PropertyClass) -> None:
     data = oai.Schema(default="B", enum=["A"])
     schemas = Schemas()


### PR DESCRIPTION
This is a naive attempt at dynamically avoiding name collisions between a Schema object's enum property type name and the name of another, user-defined, Schema type.

Pros: All tests pass
Cons: I have no idea what I'm doing.

This is proposed to advance the discussion, all suggestions and guidance are most welcome.

Resolves #1167 (Allegedly)