### PR TITLE
fix forward type reference in Pydantic schemas

### DIFF
--- a/.changeset/pydantic-cycle-fix.md
+++ b/.changeset/pydantic-cycle-fix.md
@@ -1,0 +1,7 @@
+---
+default: patch
+---
+
+# Fix for rare Pydantic error
+
+Fixed a subtle issue with forward type references in Pydantic classes that could, in very rare cases, cause the parser to fail with the error "`Parameter` is not fully defined".

--- a/openapi_python_client/schema/openapi_schema_pydantic/header.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/header.py
@@ -29,3 +29,10 @@ class Header(Parameter):
             ]
         },
     )
+
+
+# Calling model_rebuild() here helps Pydantic to resolve the forward references that were used
+# in defining Parameter and Encoding. Without this call, any subtle change to the loading order
+# of schema submodules could result in an error like "Parameter is not fully defined".
+# See: https://docs.pydantic.dev/latest/concepts/models/#rebuilding-model-schema
+Parameter.model_rebuild()


### PR DESCRIPTION
This small change addresses an issue that, unfortunately, I don't have a good test case to demonstrate. I've only been able to reproduce it with one specific API spec file... and only in my fork. Ordinarily I wouldn't submit an upstream change due to something that's only ever happened in my fork. However, in this case:

1. I never changed any code in `openapi_schema_pydantic/` in this fork.
2. The code path that is raising the error also has no changes. It's [this line](https://github.com/benchling/openapi-python-client/blob/pydantic-forward-ref-fix/openapi_python_client/parser/properties/schemas.py#L166) in `schemas.py`, where it's trying to construct a `Parameter` instance. The error message ("`Parameter` is not fully defined") indicates that the problem is not the arguments to the `Parameter` initializer—it's the `Parameter` class itself, which Pydantic considers to be invalid. The message also indicates that the "not fully defined" part is a forward reference to the `Header` class.
3. The forward reference (in [`encoding.py`](https://github.com/benchling/openapi-python-client/blob/pydantic-forward-ref-fix/openapi_python_client/schema/openapi_schema_pydantic/encoding.py#L10)) existed in order to avoid an import cycle between `Parameter`, `Encoding`, and `Header`. That should be fine, and was working fine till now with exactly the same code in these Pydantic models. However...
4. Per the Pydantic docs, the logic for lazily resolving forward references is [extremely complicated](https://docs.pydantic.dev/latest/internals/resolving_annotations/#resolving-annotations-when-rebuilding-a-model), and in some hard-to-define cases it can fail. In that case they advise doing what I've done here: calling `model_rebuild()` on the class that's getting the error, after the previously-undefined class has been defined.

Because of all that, my theory is that there is some extremely subtle interaction between my _other_ changes in the fork which, under some very specific conditions related to the particular spec I was testing with, maybe led to modules being imported in a different order... or something like that. This apparently had no effect on anything else, but made a difference in Pydantic's lazy-resolve mechanism. I can't characterize it any better than that, and I don't know how to write a test for it (although this fix does solve my use case). But I do believe this workaround is valid according to [the docs](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_rebuild) and doesn't cause problems under any other circumstances. And I suspect that the circumstances under which it was working were brittle enough that some other completely unrelated change could've eventually caused it to manifest in an equally confusing way, so you could see this as a fix-in-advance for that.

(The problem is _not_ that `header.py` hadn't actually been imported before that line in `schemas.py` executed. I verified 100% for sure that it had been. It's something more subtle than that.)