### PR TITLE
Enumerate duplicate model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If this option results in conflicts, you will need to manually override class na
 
 Even with `use_path_prefixes_for_title_model_names` set to `true`, duplicate model class names can occur. By default, when duplicates are encountered they will be skipped.
 
-Setting `enumerate_duplicate_model_names` to `true` in your config file will result in a number being added to duplicate names starting with 2. For instance, if `MyModelName` already exists, then the next time a model with that name is encountered, it will be named `MyModelName2`, then `MyModelName3` and so on.
+Setting `enumerate_duplicate_model_names` to `true` in your config file will result in a number being added to duplicate names starting with 1. For instance, if there are multiple occurances in the schema of `MyModelName`, the initial occurance will remain `MyModelName` and subsequent occurances will be named `MyModelName1`, `MyModelName2` and so on.
 
 ### http_timeout
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ If you are carefully curating your `title` properties already to ensure no dupli
 
 If this option results in conflicts, you will need to manually override class names instead via the `class_overrides` option.
 
+### enumerate_duplicate_model_names
+
+Even with `use_path_prefixes_for_title_model_names` set to `true`, duplicate model class names can occur. By default, when duplicates are encountered they will be skipped.
+
+Setting `enumerate_duplicate_model_names` to `true` in your config file will result in a number being added to duplicate names starting with 2. For instance, if `MyModelName` already exists, then the next time a model with that name is encountered, it will be named `MyModelName2`, then `MyModelName3` and so on.
+
 ### http_timeout
 
 By default, the timeout for retrieving the schema file via HTTP is 5 seconds. In case there is an error when retrieving the schema, you might try and increase this setting to a higher value.

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If this option results in conflicts, you will need to manually override class na
 
 Even with `use_path_prefixes_for_title_model_names` set to `true`, duplicate model class names can occur. By default, when duplicates are encountered they will be skipped.
 
-Setting `enumerate_duplicate_model_names` to `true` in your config file will result in a number being added to duplicate names starting with 1. For instance, if there are multiple occurances in the schema of `MyModelName`, the initial occurance will remain `MyModelName` and subsequent occurances will be named `MyModelName1`, `MyModelName2` and so on.
+Setting `enumerate_duplicate_model_names` to `true` in your config file will result in a number being added to duplicate names starting with 1. For instance, if there are multiple occurrences in the schema of `MyModelName`, the initial occurrence will remain `MyModelName` and subsequent occurrences will be named `MyModelName1`, `MyModelName2` and so on.
 
 ### http_timeout
 

--- a/openapi_python_client/config.py
+++ b/openapi_python_client/config.py
@@ -40,6 +40,7 @@ class ConfigFile(BaseModel):
     package_name_override: Optional[str] = None
     package_version_override: Optional[str] = None
     use_path_prefixes_for_title_model_names: bool = True
+    enumerate_duplicate_model_names: bool = False
     post_hooks: Optional[list[str]] = None
     docstrings_on_attributes: bool = False
     field_prefix: str = "field_"
@@ -70,6 +71,7 @@ class Config:
     package_name_override: Optional[str]
     package_version_override: Optional[str]
     use_path_prefixes_for_title_model_names: bool
+    enumerate_duplicate_model_names: bool
     post_hooks: list[str]
     docstrings_on_attributes: bool
     field_prefix: str
@@ -112,6 +114,7 @@ class Config:
             package_name_override=config_file.package_name_override,
             package_version_override=config_file.package_version_override,
             use_path_prefixes_for_title_model_names=config_file.use_path_prefixes_for_title_model_names,
+            enumerate_duplicate_model_names=config_file.enumerate_duplicate_model_names,
             post_hooks=post_hooks,
             docstrings_on_attributes=config_file.docstrings_on_attributes,
             field_prefix=config_file.field_prefix,

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -74,6 +74,11 @@ class ModelProperty(PropertyProtocol):
             else:
                 class_string = title
         class_info = Class.from_string(string=class_string, config=config)
+        if config.enumerate_duplicate_model_names:
+            suffix = 2
+            while class_info.name in schemas.classes_by_name:
+                class_info = Class.from_string(string=class_string + str(suffix), config=config)
+                suffix += 1
         model_roots = {*roots, class_info.name}
         required_properties: list[Property] | None = None
         optional_properties: list[Property] | None = None

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -75,7 +75,7 @@ class ModelProperty(PropertyProtocol):
                 class_string = title
         class_info = Class.from_string(string=class_string, config=config)
         if config.enumerate_duplicate_model_names:
-            suffix = 2
+            suffix = 1
             while class_info.name in schemas.classes_by_name:
                 class_info = Class.from_string(string=class_string + str(suffix), config=config)
                 suffix += 1


### PR DESCRIPTION
This addresses: https://github.com/openapi-generators/openapi-python-client/issues/652

Even with `use_path_prefixes_for_title_model_names` set to `true`, duplicate model class names can occur. By default, when duplicates are encountered they will be skipped. This can cause error when they are referenced later.

This PR enables setting `enumerate_duplicate_model_names` to `true` (`false` by default) in the config file which will result in a number being added to duplicate names starting with 1. For instance, if there are multiple occurrences in the schema of `MyModelName`, the initial occurrence will remain `MyModelName` and subsequent occurrences will be named `MyModelName1`, `MyModelName2` and so on.

The existing `test_model_name_conflict` test is updated to account for this new config option.