### PR TITLE
test: Rename python to python3 in tests

### DIFF
--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -42,23 +42,23 @@ class TestProject:
         assert fake_command_name in error.detail
 
     def test__run_post_hooks_reports_stdout_of_commands_that_error_with_no_stderr(self, project_with_dir):
-        failing_command = "python -c \"print('a message'); exit(1)\""
+        failing_command = "python3 -c \"print('a message'); exit(1)\""
         project_with_dir.config.post_hooks = [failing_command]
         project_with_dir._run_post_hooks()
 
         assert len(project_with_dir.errors) == 1
         error = project_with_dir.errors[0]
         assert error.level == ErrorLevel.ERROR
-        assert error.header == "python failed"
+        assert error.header == "python3 failed"
         assert "a message" in error.detail
 
     def test__run_post_hooks_reports_stderr_of_commands_that_error(self, project_with_dir):
-        failing_command = "python -c \"print('a message'); raise Exception('some exception')\""
+        failing_command = "python3 -c \"print('a message'); raise Exception('some exception')\""
         project_with_dir.config.post_hooks = [failing_command]
         project_with_dir._run_post_hooks()
 
         assert len(project_with_dir.errors) == 1
         error = project_with_dir.errors[0]
         assert error.level == ErrorLevel.ERROR
-        assert error.header == "python failed"
+        assert error.header == "python3 failed"
         assert "some exception" in error.detail


### PR DESCRIPTION
This commit renames the invocation of `python` to `python3` in the tests.

While many systems now alias `python` to `python3`, this behavior is not
guaranteed across all environments and is often configured by the user,
rather than provided by the operating system directly.

Explicitly using `python3` ensures that the tests are executed with the
intended Python 3 interpreter, regardless of user-specific configurations,
and therefore improves the portability and reliability of the test suite.
