### PR TITLE
docs: add module docstring for endpoint init template

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/config/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/config/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/defaults/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/defaults/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/enums/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/enums/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag2/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag2/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/__init__.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/__init__.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/__init__.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/__init__.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/__init__.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/integration-tests/integration_tests/api/body/__init__.py
+++ b/integration-tests/integration_tests/api/body/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/integration-tests/integration_tests/api/parameters/__init__.py
+++ b/integration-tests/integration_tests/api/parameters/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/openapi_python_client/templates/endpoint_init.py.jinja
+++ b/openapi_python_client/templates/endpoint_init.py.jinja
@@ -1,0 +1,1 @@
+""" Contains endpoint functions for accessing the API """


### PR DESCRIPTION
This commit adds a docstring to the jinja template file to prevent it from being empty.
