### PR TITLE
feat(uv): Switch to `uv_build` build backend.

### DIFF
--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -19,7 +19,7 @@ data = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.0,<1"]
+requires = ["uv_build>=0.8.0,<0.9.0"]
 build-backend = "uv_build"
 
 [tool.ruff]

--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -11,23 +11,16 @@ dependencies = [
     "python-dateutil>=2.8.0,<3",
 ]
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "test_3_1_features_client",
+[tool.uv.build-backend]
+module-name = "test_3_1_features_client"
+module-root = ""
+data = [
     "CHANGELOG.md",
-    "test_3_1_features_client/py.typed",
-]
-
-[tool.hatch.build.targets.wheel]
-include = [
-    "test_3_1_features_client",
-    "CHANGELOG.md",
-    "test_3_1_features_client/py.typed",
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.8.0,<1"]
+build-backend = "uv_build"
 
 [tool.ruff]
 line-length = 120

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -11,20 +11,13 @@ dependencies = [
     "python-dateutil>=2.8.0,<3",
 ]
 
-[tool.hatch.build.targets.sdist]
-include = [
-    "{{ package_name }}",
+[tool.uv.build-backend]
+module-name = "{{ package_name }}"
+module-root = ""
+data = [
     "CHANGELOG.md",
-    "{{ package_name }}/py.typed",
-]
-
-[tool.hatch.build.targets.wheel]
-include = [
-    "{{ package_name }}",
-    "CHANGELOG.md",
-    "{{ package_name }}/py.typed",
 ]
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.8.0,<1"]
+build-backend = "uv_build"

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -19,5 +19,5 @@ data = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.0,<1"]
+requires = ["uv_build>=0.8.0,<0.9.0"]
 build-backend = "uv_build"


### PR DESCRIPTION
This has become the `uv` default in `0.8.0`.

See https://github.com/astral-sh/uv/releases/tag/0.8.0