### PR TITLE
refactor(poetry): Set `build-backend` of poetry to latest recommended…

### DIFF
--- a/end_to_end_tests/docstrings-on-attributes-golden-record/pyproject.toml
+++ b/end_to_end_tests/docstrings-on-attributes-golden-record/pyproject.toml
@@ -16,7 +16,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/end_to_end_tests/golden-record/pyproject.toml
+++ b/end_to_end_tests/golden-record/pyproject.toml
@@ -16,7 +16,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/end_to_end_tests/literal-enums-golden-record/pyproject.toml
+++ b/end_to_end_tests/literal-enums-golden-record/pyproject.toml
@@ -16,7 +16,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/end_to_end_tests/metadata_snapshots/poetry.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/poetry.pyproject.toml
@@ -16,7 +16,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/end_to_end_tests/test-3-1-golden-record/pyproject.toml
+++ b/end_to_end_tests/test-3-1-golden-record/pyproject.toml
@@ -16,7 +16,7 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]

--- a/openapi_python_client/templates/pyproject_poetry.toml.jinja
+++ b/openapi_python_client/templates/pyproject_poetry.toml.jinja
@@ -16,5 +16,5 @@ attrs = ">=22.2.0"
 python-dateutil = "^2.8.0"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
… dependency pin.

See https://python-poetry.org/docs/basic-usage/#project-setup and https://github.com/openapi-generators/openapi-python-client/pull/1290#discussion_r2219606772