### PR TITLE
feat(parser): #1271 Support simple patterned http status codes

### DIFF
--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -67,7 +67,11 @@ def _get_kwargs(
 
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
     {% for response in endpoint.responses %}
+    {% if response.status_code.value is defined %}
     if response.status_code == {{ response.status_code.value }}:
+    {% else %}
+    if {{ response.status_code[0].value }} <= response.status_code <= {{ response.status_code[1] }}:
+    {% endif %}
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
         {% if prop_template.construct %}
         {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}

--- a/tests/test_parser/test_responses.py
+++ b/tests/test_parser/test_responses.py
@@ -240,6 +240,7 @@ def test_response_from_data_content_type_overrides(any_property_factory):
     config = MagicMock()
     config.content_type_overrides = {"application/zip": "application/octet-stream"}
     response, schemas = response_from_data(
+        status_code_str="200",
         status_code=200,
         data=data,
         schemas=Schemas(),


### PR DESCRIPTION
Support status code patterns such as `2XX`, ...

[
](https://github.com/openapi-generators/openapi-python-client/issues/1271)

> **Describe the bug** [Documentation](https://github.com/openapi-generators/openapi-python-client/blob/61b6c54994e2a6285bb422ee3b864c45b5d88c15/openapi_python_client/schema/3.1.0.md?plain=1#L1671) indicates that patterned HTTP status codes may be used for Response Objects. Supply a patterened HTTP status code in this manner results in the following warning: `Invalid response status code 4XX (not a valid HTTP status code), response will be omitted from generated client`