### PR TITLE
feat: Add handling of OpenAPI endpoint default responses

### DIFF
--- a/end_to_end_tests/baseline_openapi_3.0.json
+++ b/end_to_end_tests/baseline_openapi_3.0.json
@@ -961,6 +961,37 @@
         }
       }
     },
+    "/responses/default": {
+      "post": {
+        "tags": [
+          "responses"
+        ],
+        "summary": "Default Response",
+        "operationId": "default_response",
+        "responses": {
+          "200": {
+            "description": "Text response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Default response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/responses/reference": {
       "get": {
         "tags": [

--- a/end_to_end_tests/baseline_openapi_3.1.yaml
+++ b/end_to_end_tests/baseline_openapi_3.1.yaml
@@ -944,6 +944,37 @@ info:
       }
     }
   },
+  "/responses/default": {
+      "post": {
+        "tags": [
+          "responses"
+        ],
+        "summary": "Default Response",
+        "operationId": "default_response",
+        "responses": {
+          "200": {
+            "description": "Text response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Default response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
   "/responses/reference": {
     "get": {
       "tags": [

--- a/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/responses/__init__.py
+++ b/end_to_end_tests/custom-templates-golden-record/my_test_api_client/api/responses/__init__.py
@@ -2,7 +2,7 @@
 
 import types
 
-from . import post_responses_unions_simple_before_complex, reference_response, text_response
+from . import default_response, post_responses_unions_simple_before_complex, reference_response, text_response
 
 
 class ResponsesEndpoints:
@@ -19,6 +19,13 @@ class ResponsesEndpoints:
         Text Response
         """
         return text_response
+
+    @classmethod
+    def default_response(cls) -> types.ModuleType:
+        """
+        Default Response
+        """
+        return default_response
 
     @classmethod
     def reference_response(cls) -> types.ModuleType:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/json_like.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/json_like.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/post_bodies_multiple.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/post_bodies_multiple.py
@@ -51,6 +51,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/refs.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/refs.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/config/content_type_override.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/config/content_type_override.py
@@ -31,6 +31,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 200:
         response_200 = cast(str, response.json())
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -30,6 +30,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_allof.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_allof.py
@@ -25,6 +25,7 @@ def _parse_response(
         response_200 = GetModelsAllofResponse200.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_oneof_with_required_const.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_oneof_with_required_const.py
@@ -52,6 +52,7 @@ def _parse_response(
         response_200 = _parse_response_200(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -30,6 +30,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/reserved_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/reserved_parameters.py
@@ -33,6 +33,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/defaults/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/defaults/defaults_tests_defaults_post.py
@@ -92,10 +92,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/enums/bool_enum_tests_bool_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/enums/bool_enum_tests_bool_enum_post.py
@@ -30,6 +30,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/enums/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/enums/int_enum_tests_int_enum_post.py
@@ -32,6 +32,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -50,6 +50,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -56,6 +56,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/hyphen_in_path.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/hyphen_in_path.py
@@ -22,6 +22,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/mixed_case.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/mixed_case.py
@@ -38,6 +38,7 @@ def _parse_response(
         response_200 = MixedCaseResponse200.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/post_naming_property_conflict_with_import.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/post_naming_property_conflict_with_import.py
@@ -38,6 +38,7 @@ def _parse_response(
         response_200 = PostNamingPropertyConflictWithImportResponse200.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -46,6 +46,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -43,6 +43,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -25,6 +25,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/default_response.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/default_response.py
@@ -3,34 +3,29 @@ from typing import Any, Optional, Union
 
 import httpx
 
-from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...models.a_model import AModel
 from ...types import Response
 
 
 def _get_kwargs() -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "get",
-        "url": "/responses/reference",
+        "method": "post",
+        "url": "/responses/default",
     }
 
     return _kwargs
 
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[AModel]:
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> str:
     if response.status_code == 200:
-        response_200 = AModel.from_dict(response.json())
-
+        response_200 = response.text
         return response_200
 
-    if client.raise_on_unexpected_status:
-        raise errors.UnexpectedStatus(response.status_code, response.content)
-    else:
-        return None
+    response_default = response.text
+    return response_default
 
 
-def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[AModel]:
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[str]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -42,15 +37,15 @@ def _build_response(*, client: Union[AuthenticatedClient, Client], response: htt
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[AModel]:
-    """Endpoint using predefined response
+) -> Response[str]:
+    """Default Response
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AModel]
+        Response[str]
     """
 
     kwargs = _get_kwargs()
@@ -65,15 +60,15 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[AModel]:
-    """Endpoint using predefined response
+) -> Optional[str]:
+    """Default Response
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AModel
+        str
     """
 
     return sync_detailed(
@@ -84,15 +79,15 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Response[AModel]:
-    """Endpoint using predefined response
+) -> Response[str]:
+    """Default Response
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[AModel]
+        Response[str]
     """
 
     kwargs = _get_kwargs()
@@ -105,15 +100,15 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-) -> Optional[AModel]:
-    """Endpoint using predefined response
+) -> Optional[str]:
+    """Default Response
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        AModel
+        str
     """
 
     return (

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
@@ -27,6 +27,7 @@ def _parse_response(
         response_200 = PostResponsesUnionsSimpleBeforeComplexResponse200.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/text_response.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/text_response.py
@@ -21,6 +21,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 200:
         response_200 = response.text
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -20,6 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag2/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag2/get_tag_with_number.py
@@ -20,6 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -35,10 +35,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -20,6 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -22,6 +22,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         response_200 = cast(list[bool], response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -22,6 +22,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         response_200 = cast(list[float], response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -22,6 +22,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         response_200 = cast(list[int], response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -22,6 +22,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         response_200 = cast(list[str], response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -75,14 +75,17 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if response.status_code == 423:
         response_423 = HTTPValidationError.from_dict(response.json())
 
         return response_423
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -35,10 +35,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -20,6 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -23,6 +23,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         response_200 = File(payload=BytesIO(response.content))
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_post.py
@@ -36,10 +36,12 @@ def _parse_response(
         response_200 = OctetStreamTestsOctetStreamPostResponse200.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -31,6 +31,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
@@ -34,10 +34,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = cast(str, response.json())
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -36,6 +36,7 @@ def _parse_response(
         response_200 = TestInlineObjectsResponse200.from_dict(response.json())
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -27,8 +27,10 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if response.status_code == 401:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -20,6 +20,7 @@ def _get_kwargs() -> dict[str, Any]:
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -33,10 +33,12 @@ def _parse_response(
     if response.status_code == 200:
         response_200 = response.json()
         return response_200
+
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
 
         return response_422
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -30,6 +30,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/bool_enum_tests_bool_enum_post.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/bool_enum_tests_bool_enum_post.py
@@ -30,6 +30,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/int_enum_tests_int_enum_post.py
@@ -32,6 +32,7 @@ def _get_kwargs(
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
     if response.status_code == 200:
         return None
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/get_user_list.py
@@ -78,6 +78,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/post_user_list.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/post_user_list.py
@@ -39,6 +39,7 @@ def _parse_response(
             response_200.append(response_200_item)
 
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
@@ -50,6 +50,7 @@ def _parse_response(
                 f"response_200 must match const 'Why have a fixed response? I dunno', got '{response_200}'"
             )
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/post_prefix_items.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/post_prefix_items.py
@@ -32,6 +32,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == 200:
         response_200 = cast(str, response.json())
         return response_200
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/integration-tests/integration_tests/api/body/post_body_multipart.py
+++ b/integration-tests/integration_tests/api/body/post_body_multipart.py
@@ -35,10 +35,12 @@ def _parse_response(
         response_200 = PostBodyMultipartResponse200.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = PublicError.from_dict(response.json())
 
         return response_400
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/integration-tests/integration_tests/api/parameters/post_parameters_header.py
+++ b/integration-tests/integration_tests/api/parameters/post_parameters_header.py
@@ -42,10 +42,12 @@ def _parse_response(
         response_200 = PostParametersHeaderResponse200.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 400:
         response_400 = PublicError.from_dict(response.json())
 
         return response_400
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:

--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -26,7 +26,7 @@ from .properties import (
     property_from_data,
 )
 from .properties.schemas import parameter_from_reference
-from .responses import Response, response_from_data
+from .responses import OpenAPIStatus, Response, response_from_data
 
 _PATH_PARAM_REGEX = re.compile("{([a-zA-Z_-][a-zA-Z0-9_-]*)}")
 
@@ -162,9 +162,9 @@ class Endpoint:
     ) -> tuple["Endpoint", Schemas]:
         endpoint = deepcopy(endpoint)
         for code, response_data in data.items():
-            status_code: HTTPStatus
+            status_code: OpenAPIStatus
             try:
-                status_code = HTTPStatus(int(code))
+                status_code = HTTPStatus(int(code)) if code != "default" else "default"
             except ValueError:
                 endpoint.errors.append(
                     ParseError(

--- a/openapi_python_client/parser/responses.py
+++ b/openapi_python_client/parser/responses.py
@@ -1,7 +1,7 @@
 __all__ = ["Response", "response_from_data"]
 
 from http import HTTPStatus
-from typing import Optional, TypedDict, Union
+from typing import Literal, Optional, TypedDict, Union
 
 from attrs import define
 
@@ -13,6 +13,8 @@ from .. import schema as oai
 from ..utils import PythonIdentifier
 from .errors import ParseError, PropertyError
 from .properties import AnyProperty, Property, Schemas, property_from_data
+
+OpenAPIStatus = Union[HTTPStatus, Literal["default"]]
 
 
 class _ResponseSource(TypedDict):
@@ -32,7 +34,7 @@ NONE_SOURCE = _ResponseSource(attribute="None", return_type="None")
 class Response:
     """Describes a single response for an endpoint"""
 
-    status_code: HTTPStatus
+    status_code: OpenAPIStatus
     prop: Property
     source: _ResponseSource
     data: Union[oai.Response, oai.Reference]  # Original data which created this response, useful for custom templates
@@ -59,7 +61,7 @@ def _source_by_content_type(content_type: str, config: Config) -> Optional[_Resp
 
 def empty_response(
     *,
-    status_code: HTTPStatus,
+    status_code: OpenAPIStatus,
     response_name: str,
     config: Config,
     data: Union[oai.Response, oai.Reference],
@@ -82,7 +84,7 @@ def empty_response(
 
 def response_from_data(  # noqa: PLR0911
     *,
-    status_code: HTTPStatus,
+    status_code: OpenAPIStatus,
     data: Union[oai.Response, oai.Reference],
     schemas: Schemas,
     responses: dict[str, Union[oai.Response, oai.Reference]],

--- a/openapi_python_client/templates/endpoint_macros.py.jinja
+++ b/openapi_python_client/templates/endpoint_macros.py.jinja
@@ -184,3 +184,18 @@ Returns:
 {% macro docstring(endpoint, return_string, is_detailed) %}
 {{ safe_docstring(docstring_content(endpoint, return_string, is_detailed)) }}
 {% endmacro %}
+
+{% macro parse_response(parsed_responses, response) %}
+{% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
+{% if prop_template.construct %}
+{{ prop_template.construct(response.prop, response.source.attribute) }}
+{% elif response.source.return_type == response.prop.get_type_string()  %}
+{{ response.prop.python_name }} = {{ response.source.attribute }}
+{% else %}
+{{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
+{% endif %}
+return {{ response.prop.python_name }}
+{% else %}
+return None
+{% endif %}
+{% endmacro %}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -12,7 +12,7 @@ from ... import errors
 {% endfor %}
 
 {% from "endpoint_macros.py.jinja" import header_params, cookie_params, query_params,
-    arguments, client, kwargs, parse_response, docstring, body_to_kwarg %}
+    arguments, client, kwargs, parse_response, docstring, body_to_kwarg, parse_response %}
 
 {% set return_string = endpoint.response_type() %}
 {% set parsed_responses = (endpoint.responses | length > 0) and return_string != "Any" %}
@@ -64,27 +64,28 @@ def _get_kwargs(
 {% endif %}
     return _kwargs
 
+{% set def_response = namespace(exists=false) %}
+{% for response in endpoint.responses if response.status_code == "default" %}
+{% set def_response.exists = true %}
+{% endfor %}
 
-def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
-    {% for response in endpoint.responses %}
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> {% if def_response.exists %}{{ return_string }}{% else %}Optional[{{ return_string }}]{% endif %}:
+    {% for response in endpoint.responses if response.status_code != "default" %}
     if response.status_code == {{ response.status_code.value }}:
-        {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
-        {% if prop_template.construct %}
-        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
-        {% elif response.source.return_type == response.prop.get_type_string()  %}
-        {{ response.prop.python_name }} = {{ response.source.attribute }}
-        {% else %}
-        {{ response.prop.python_name }} = cast({{ response.prop.get_type_string() }}, {{ response.source.attribute }})
-        {% endif %}
-        return {{ response.prop.python_name }}
-        {% else %}
-        return None
-        {% endif %}
+{{ parse_response(parsed_responses, response) | indent(8, first=true, blank=true) }}
     {% endfor %}
+    {% for response in endpoint.responses if response.status_code == "default" %}
+{{ parse_response(parsed_responses, response) | indent(4, first=true, blank=true) }}
+    {% endfor %}
+    {% if not def_response.exists %}
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
         return None
+    {% endif %}
 
 
 def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[{{ return_string }}]:


### PR DESCRIPTION
Addresses feature request for handling default responses: https://github.com/openapi-generators/openapi-python-client/discussions/832

This treats the string literal `"default"` as an alternative form of status code for the internal `Response` object and handles parsing it appropriately in the `Endpoint` class parser. This takes the form of replacing a few instances of `HTTPStatus` with a union type alias and a conditional check on consuming that response field. Since this is now a normal `Response` object added to the `Endpoint`, the return type handling includes its output type appropriately.

This additionally modifies the endpoint template to consume this alternative form of status code, making that default `Response` the handler for any unspecified status codes. Since now all status codes are now handled, it removes the fallback unexpected status handler code and changes the return typing of the `_parse_response` function to match. This breaks out the response handling into a Jinja macro so as to not duplicate that code template bit.

The effect of this is that when `default` is used as a possible response for an endpoint, it will be treated as any other response type/code would be except that it serves as the fallback for all possible HTTP responses in the runtime response parser, which is how I understand the spec to describe this feature. If a default response object is not present, there are no changes to the generated code compared to before these changes (except for the addition of a blank line, if this is a problem I still need to figure out how to make it go away, it wasn't straightforward to me).

I wasn't totally sure about testing, so I added a functional test that ensures that the generated endpoint contains the changes to the return typing now that it will always return some (only if there is a default response object) and added a new endpoint to both the 3.0 and 3.1 e2e test APIs and regenerated the snapshots. I'm happy to take feedback and change how the testing works if this isn't appropriate.