### PR TITLE
test: fix test_bad_config failure due to Click 8.2.0 breaking change

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def test_bad_config() -> None:
     result = runner.invoke(app, ["generate", f"--config={config_path}", f"--path={path}"])
 
     assert result.exit_code == 2
-    assert "Unable to parse config" in result.stdout
+    assert "Unable to parse config" in result.output
 
 
 class TestGenerate:


### PR DESCRIPTION
Fixes test failure in test_bad_config caused by Click 8.2.0+ behavior change. Click 8.2.0+ now keeps stdout and stderr streams separate by default.

Fixes #1308