### PR TITLE
fix: ambigious tilde specifier requires-python with`--meta=uv`

### DIFF
--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -3,7 +3,7 @@ name = "test-3-1-features-client"
 version = "0.1.0"
 description = "A client library for accessing Test 3.1 Features"
 authors = []
-requires-python = "~=3.9"
+requires-python = ">=3.9,<4.0"
 readme = "README.md"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -3,7 +3,7 @@ name = "{{ project_name }}"
 version = "{{ package_version }}"
 description = "{{ package_description }}"
 authors = []
-requires-python = "~=3.9"
+requires-python = ">=3.9,<4.0"
 readme = "README.md"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",


### PR DESCRIPTION
Clients generated like this:
```
uv run openapi-python-client generate --path openapi.json --overwrite --output-path client --meta uv
```
Generate these warnings during installation with `uv`:
> warning: The `requires-python` specifier (`~=3.9`) in `client` uses the tilde specifier (`~=`) without a patch version. This will be interpreted as `>=3.9, <4`. Did you mean `~=3.9.0` to constrain the version as `>=3.9.0, <3.10`? We recommend only using the tilde specifier with a patch version to avoid ambiguity.