### PR TITLE
fix: Drop generated `requires-python` upper bounds for uv and PDM

### DIFF
--- a/end_to_end_tests/metadata_snapshots/pdm.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/pdm.pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A client library for accessing Test 3.1 Features"
 authors = []
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",
     "attrs>=22.2.0",

--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -3,7 +3,7 @@ name = "test-3-1-features-client"
 version = "0.1.0"
 description = "A client library for accessing Test 3.1 Features"
 authors = []
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9"
 readme = "README.md"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",

--- a/openapi_python_client/templates/pyproject_pdm.toml.jinja
+++ b/openapi_python_client/templates/pyproject_pdm.toml.jinja
@@ -4,7 +4,7 @@ version = "{{ package_version }}"
 description = "{{ package_description }}"
 authors = []
 readme = "README.md"
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",
     "attrs>=22.2.0",

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -3,7 +3,7 @@ name = "{{ project_name }}"
 version = "{{ package_version }}"
 description = "{{ package_description }}"
 authors = []
-requires-python = ">=3.9,<4.0"
+requires-python = ">=3.9"
 readme = "README.md"
 dependencies = [
     "httpx>=0.23.0,<0.29.0",


### PR DESCRIPTION
`requires-python` has a long and sorted history in the Python community

- https://docs.astral.sh/uv/concepts/resolution/#universal-resolution

> When evaluating requires-python ranges for dependencies, uv only considers lower bounds and ignores upper bounds entirely. For example, >=3.8, <4 is treated as >=3.8

Remove the upper bound on generated clients to avoid pushing users into this without need.