### PR TITLE
fix: Initialize optional lists as UNSET, not []

### DIFF
--- a/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/a_model.py
@@ -395,17 +395,19 @@ class AModel:
         else:
             an_optional_allof_enum = AnAllOfEnum(_an_optional_allof_enum)
 
-        nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
-        for nested_list_of_enums_item_data in _nested_list_of_enums or []:
-            nested_list_of_enums_item = []
-            _nested_list_of_enums_item = nested_list_of_enums_item_data
-            for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
-                nested_list_of_enums_item_item = DifferentEnum(nested_list_of_enums_item_item_data)
+        nested_list_of_enums: list[list[DifferentEnum]] | Unset = UNSET
+        if _nested_list_of_enums is not UNSET:
+            nested_list_of_enums = []
+            for nested_list_of_enums_item_data in _nested_list_of_enums:
+                nested_list_of_enums_item = []
+                _nested_list_of_enums_item = nested_list_of_enums_item_data
+                for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
+                    nested_list_of_enums_item_item = DifferentEnum(nested_list_of_enums_item_item_data)
 
-                nested_list_of_enums_item.append(nested_list_of_enums_item_item)
+                    nested_list_of_enums_item.append(nested_list_of_enums_item_item)
 
-            nested_list_of_enums.append(nested_list_of_enums_item)
+                nested_list_of_enums.append(nested_list_of_enums_item)
 
         _a_not_required_date = d.pop("a_not_required_date", UNSET)
         a_not_required_date: datetime.date | Unset

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_circular_ref_in_items_object_a_item.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_circular_ref_in_items_object_a_item.py
@@ -50,16 +50,18 @@ class AnArrayWithACircularRefInItemsObjectAItem:
         )
 
         d = dict(src_dict)
-        circular = []
         _circular = d.pop("circular", UNSET)
-        for componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item_data in _circular or []:
-            componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item = (
-                AnArrayWithACircularRefInItemsObjectBItem.from_dict(
-                    componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item_data
+        circular: list[AnArrayWithACircularRefInItemsObjectBItem] | Unset = UNSET
+        if _circular is not UNSET:
+            circular = []
+            for componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item_data in _circular:
+                componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item = (
+                    AnArrayWithACircularRefInItemsObjectBItem.from_dict(
+                        componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item_data
+                    )
                 )
-            )
 
-            circular.append(componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item)
+                circular.append(componentsschemas_an_array_with_a_circular_ref_in_items_object_b_item)
 
         an_array_with_a_circular_ref_in_items_object_a_item = cls(
             circular=circular,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_circular_ref_in_items_object_b_item.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_circular_ref_in_items_object_b_item.py
@@ -50,16 +50,18 @@ class AnArrayWithACircularRefInItemsObjectBItem:
         )
 
         d = dict(src_dict)
-        circular = []
         _circular = d.pop("circular", UNSET)
-        for componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item_data in _circular or []:
-            componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item = (
-                AnArrayWithACircularRefInItemsObjectAItem.from_dict(
-                    componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item_data
+        circular: list[AnArrayWithACircularRefInItemsObjectAItem] | Unset = UNSET
+        if _circular is not UNSET:
+            circular = []
+            for componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item_data in _circular:
+                componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item = (
+                    AnArrayWithACircularRefInItemsObjectAItem.from_dict(
+                        componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item_data
+                    )
                 )
-            )
 
-            circular.append(componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item)
+                circular.append(componentsschemas_an_array_with_a_circular_ref_in_items_object_a_item)
 
         an_array_with_a_circular_ref_in_items_object_b_item = cls(
             circular=circular,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_recursive_ref_in_items_object_item.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/an_array_with_a_recursive_ref_in_items_object_item.py
@@ -42,16 +42,18 @@ class AnArrayWithARecursiveRefInItemsObjectItem:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        recursive = []
         _recursive = d.pop("recursive", UNSET)
-        for componentsschemas_an_array_with_a_recursive_ref_in_items_object_item_data in _recursive or []:
-            componentsschemas_an_array_with_a_recursive_ref_in_items_object_item = (
-                AnArrayWithARecursiveRefInItemsObjectItem.from_dict(
-                    componentsschemas_an_array_with_a_recursive_ref_in_items_object_item_data
+        recursive: list[AnArrayWithARecursiveRefInItemsObjectItem] | Unset = UNSET
+        if _recursive is not UNSET:
+            recursive = []
+            for componentsschemas_an_array_with_a_recursive_ref_in_items_object_item_data in _recursive:
+                componentsschemas_an_array_with_a_recursive_ref_in_items_object_item = (
+                    AnArrayWithARecursiveRefInItemsObjectItem.from_dict(
+                        componentsschemas_an_array_with_a_recursive_ref_in_items_object_item_data
+                    )
                 )
-            )
 
-            recursive.append(componentsschemas_an_array_with_a_recursive_ref_in_items_object_item)
+                recursive.append(componentsschemas_an_array_with_a_recursive_ref_in_items_object_item)
 
         an_array_with_a_recursive_ref_in_items_object_item = cls(
             recursive=recursive,

--- a/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/body_upload_file_tests_upload_post.py
@@ -316,18 +316,20 @@ class BodyUploadFileTestsUploadPost:
 
         some_nullable_number = _parse_some_nullable_number(d.pop("some_nullable_number", UNSET))
 
-        some_int_array = []
         _some_int_array = d.pop("some_int_array", UNSET)
-        for some_int_array_item_data in _some_int_array or []:
+        some_int_array: list[int | None] | Unset = UNSET
+        if _some_int_array is not UNSET:
+            some_int_array = []
+            for some_int_array_item_data in _some_int_array:
 
-            def _parse_some_int_array_item(data: object) -> int | None:
-                if data is None:
-                    return data
-                return cast(int | None, data)
+                def _parse_some_int_array_item(data: object) -> int | None:
+                    if data is None:
+                        return data
+                    return cast(int | None, data)
 
-            some_int_array_item = _parse_some_int_array_item(some_int_array_item_data)
+                some_int_array_item = _parse_some_int_array_item(some_int_array_item_data)
 
-            some_int_array.append(some_int_array_item)
+                some_int_array.append(some_int_array_item)
 
         def _parse_some_array(data: object) -> list[AFormData] | None | Unset:
             if data is None:

--- a/end_to_end_tests/golden-record/my_test_api_client/models/extended.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/extended.py
@@ -402,17 +402,19 @@ class Extended:
         else:
             an_optional_allof_enum = AnAllOfEnum(_an_optional_allof_enum)
 
-        nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
-        for nested_list_of_enums_item_data in _nested_list_of_enums or []:
-            nested_list_of_enums_item = []
-            _nested_list_of_enums_item = nested_list_of_enums_item_data
-            for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
-                nested_list_of_enums_item_item = DifferentEnum(nested_list_of_enums_item_item_data)
+        nested_list_of_enums: list[list[DifferentEnum]] | Unset = UNSET
+        if _nested_list_of_enums is not UNSET:
+            nested_list_of_enums = []
+            for nested_list_of_enums_item_data in _nested_list_of_enums:
+                nested_list_of_enums_item = []
+                _nested_list_of_enums_item = nested_list_of_enums_item_data
+                for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
+                    nested_list_of_enums_item_item = DifferentEnum(nested_list_of_enums_item_item_data)
 
-                nested_list_of_enums_item.append(nested_list_of_enums_item_item)
+                    nested_list_of_enums_item.append(nested_list_of_enums_item_item)
 
-            nested_list_of_enums.append(nested_list_of_enums_item)
+                nested_list_of_enums.append(nested_list_of_enums_item)
 
         _a_not_required_date = d.pop("a_not_required_date", UNSET)
         a_not_required_date: datetime.date | Unset

--- a/end_to_end_tests/golden-record/my_test_api_client/models/http_validation_error.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/models/http_validation_error.py
@@ -44,12 +44,14 @@ class HTTPValidationError:
         from ..models.validation_error import ValidationError
 
         d = dict(src_dict)
-        detail = []
         _detail = d.pop("detail", UNSET)
-        for detail_item_data in _detail or []:
-            detail_item = ValidationError.from_dict(detail_item_data)
+        detail: list[ValidationError] | Unset = UNSET
+        if _detail is not UNSET:
+            detail = []
+            for detail_item_data in _detail:
+                detail_item = ValidationError.from_dict(detail_item_data)
 
-            detail.append(detail_item)
+                detail.append(detail_item)
 
         http_validation_error = cls(
             detail=detail,

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/models/a_model.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/models/a_model.py
@@ -86,17 +86,19 @@ class AModel:
         else:
             an_optional_allof_enum = check_an_all_of_enum(_an_optional_allof_enum)
 
-        nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
-        for nested_list_of_enums_item_data in _nested_list_of_enums or []:
-            nested_list_of_enums_item = []
-            _nested_list_of_enums_item = nested_list_of_enums_item_data
-            for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
-                nested_list_of_enums_item_item = check_different_enum(nested_list_of_enums_item_item_data)
+        nested_list_of_enums: list[list[DifferentEnum]] | Unset = UNSET
+        if _nested_list_of_enums is not UNSET:
+            nested_list_of_enums = []
+            for nested_list_of_enums_item_data in _nested_list_of_enums:
+                nested_list_of_enums_item = []
+                _nested_list_of_enums_item = nested_list_of_enums_item_data
+                for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
+                    nested_list_of_enums_item_item = check_different_enum(nested_list_of_enums_item_item_data)
 
-                nested_list_of_enums_item.append(nested_list_of_enums_item_item)
+                    nested_list_of_enums_item.append(nested_list_of_enums_item_item)
 
-            nested_list_of_enums.append(nested_list_of_enums_item)
+                nested_list_of_enums.append(nested_list_of_enums_item)
 
         a_model = cls(
             an_enum_value=an_enum_value,

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/models/post_user_list_body.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/models/post_user_list_body.py
@@ -158,33 +158,37 @@ class PostUserListBody:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        an_enum_value = []
         _an_enum_value = d.pop("an_enum_value", UNSET)
-        for an_enum_value_item_data in _an_enum_value or []:
-            an_enum_value_item = check_an_enum(an_enum_value_item_data)
+        an_enum_value: list[AnEnum] | Unset = UNSET
+        if _an_enum_value is not UNSET:
+            an_enum_value = []
+            for an_enum_value_item_data in _an_enum_value:
+                an_enum_value_item = check_an_enum(an_enum_value_item_data)
 
-            an_enum_value.append(an_enum_value_item)
+                an_enum_value.append(an_enum_value_item)
 
-        an_enum_value_with_null = []
         _an_enum_value_with_null = d.pop("an_enum_value_with_null", UNSET)
-        for an_enum_value_with_null_item_data in _an_enum_value_with_null or []:
+        an_enum_value_with_null: list[AnEnumWithNull | None] | Unset = UNSET
+        if _an_enum_value_with_null is not UNSET:
+            an_enum_value_with_null = []
+            for an_enum_value_with_null_item_data in _an_enum_value_with_null:
 
-            def _parse_an_enum_value_with_null_item(data: object) -> AnEnumWithNull | None:
-                if data is None:
-                    return data
-                try:
-                    if not isinstance(data, str):
-                        raise TypeError()
-                    componentsschemas_an_enum_with_null_type_1 = check_an_enum_with_null(data)
+                def _parse_an_enum_value_with_null_item(data: object) -> AnEnumWithNull | None:
+                    if data is None:
+                        return data
+                    try:
+                        if not isinstance(data, str):
+                            raise TypeError()
+                        componentsschemas_an_enum_with_null_type_1 = check_an_enum_with_null(data)
 
-                    return componentsschemas_an_enum_with_null_type_1
-                except:  # noqa: E722
-                    pass
-                return cast(AnEnumWithNull | None, data)
+                        return componentsschemas_an_enum_with_null_type_1
+                    except:  # noqa: E722
+                        pass
+                    return cast(AnEnumWithNull | None, data)
 
-            an_enum_value_with_null_item = _parse_an_enum_value_with_null_item(an_enum_value_with_null_item_data)
+                an_enum_value_with_null_item = _parse_an_enum_value_with_null_item(an_enum_value_with_null_item_data)
 
-            an_enum_value_with_null.append(an_enum_value_with_null_item)
+                an_enum_value_with_null.append(an_enum_value_with_null_item)
 
         an_enum_value_with_only_null = cast(list[None], d.pop("an_enum_value_with_only_null", UNSET))
 
@@ -202,17 +206,19 @@ class PostUserListBody:
         else:
             an_optional_allof_enum = check_an_all_of_enum(_an_optional_allof_enum)
 
-        nested_list_of_enums = []
         _nested_list_of_enums = d.pop("nested_list_of_enums", UNSET)
-        for nested_list_of_enums_item_data in _nested_list_of_enums or []:
-            nested_list_of_enums_item = []
-            _nested_list_of_enums_item = nested_list_of_enums_item_data
-            for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
-                nested_list_of_enums_item_item = check_different_enum(nested_list_of_enums_item_item_data)
+        nested_list_of_enums: list[list[DifferentEnum]] | Unset = UNSET
+        if _nested_list_of_enums is not UNSET:
+            nested_list_of_enums = []
+            for nested_list_of_enums_item_data in _nested_list_of_enums:
+                nested_list_of_enums_item = []
+                _nested_list_of_enums_item = nested_list_of_enums_item_data
+                for nested_list_of_enums_item_item_data in _nested_list_of_enums_item:
+                    nested_list_of_enums_item_item = check_different_enum(nested_list_of_enums_item_item_data)
 
-                nested_list_of_enums_item.append(nested_list_of_enums_item_item)
+                    nested_list_of_enums_item.append(nested_list_of_enums_item_item)
 
-            nested_list_of_enums.append(nested_list_of_enums_item)
+                nested_list_of_enums.append(nested_list_of_enums_item)
 
         post_user_list_body = cls(
             an_enum_value=an_enum_value,

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_prefix_items_body.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/models/post_prefix_items_body.py
@@ -53,33 +53,37 @@ class PostPrefixItemsBody:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        prefix_items_and_items = []
         _prefix_items_and_items = d.pop("prefixItemsAndItems", UNSET)
-        for prefix_items_and_items_item_data in _prefix_items_and_items or []:
+        prefix_items_and_items: list[float | Literal["prefix"] | str] | Unset = UNSET
+        if _prefix_items_and_items is not UNSET:
+            prefix_items_and_items = []
+            for prefix_items_and_items_item_data in _prefix_items_and_items:
 
-            def _parse_prefix_items_and_items_item(data: object) -> float | Literal["prefix"] | str:
-                prefix_items_and_items_item_type_0 = cast(Literal["prefix"], data)
-                if prefix_items_and_items_item_type_0 != "prefix":
-                    raise ValueError(
-                        f"prefixItemsAndItems_item_type_0 must match const 'prefix', got '{prefix_items_and_items_item_type_0}'"
-                    )
-                return prefix_items_and_items_item_type_0
-                return cast(float | Literal["prefix"] | str, data)
+                def _parse_prefix_items_and_items_item(data: object) -> float | Literal["prefix"] | str:
+                    prefix_items_and_items_item_type_0 = cast(Literal["prefix"], data)
+                    if prefix_items_and_items_item_type_0 != "prefix":
+                        raise ValueError(
+                            f"prefixItemsAndItems_item_type_0 must match const 'prefix', got '{prefix_items_and_items_item_type_0}'"
+                        )
+                    return prefix_items_and_items_item_type_0
+                    return cast(float | Literal["prefix"] | str, data)
 
-            prefix_items_and_items_item = _parse_prefix_items_and_items_item(prefix_items_and_items_item_data)
+                prefix_items_and_items_item = _parse_prefix_items_and_items_item(prefix_items_and_items_item_data)
 
-            prefix_items_and_items.append(prefix_items_and_items_item)
+                prefix_items_and_items.append(prefix_items_and_items_item)
 
-        prefix_items_only = []
         _prefix_items_only = d.pop("prefixItemsOnly", UNSET)
-        for prefix_items_only_item_data in _prefix_items_only or []:
+        prefix_items_only: list[float | str] | Unset = UNSET
+        if _prefix_items_only is not UNSET:
+            prefix_items_only = []
+            for prefix_items_only_item_data in _prefix_items_only:
 
-            def _parse_prefix_items_only_item(data: object) -> float | str:
-                return cast(float | str, data)
+                def _parse_prefix_items_only_item(data: object) -> float | str:
+                    return cast(float | str, data)
 
-            prefix_items_only_item = _parse_prefix_items_only_item(prefix_items_only_item_data)
+                prefix_items_only_item = _parse_prefix_items_only_item(prefix_items_only_item_data)
 
-            prefix_items_only.append(prefix_items_only_item)
+                prefix_items_only.append(prefix_items_only_item)
 
         post_prefix_items_body = cls(
             prefix_items_and_items=prefix_items_and_items,

--- a/integration-tests/integration_tests/models/public_error.py
+++ b/integration-tests/integration_tests/models/public_error.py
@@ -74,12 +74,14 @@ class PublicError:
 
         extra_parameters = cast(list[str], d.pop("extra_parameters", UNSET))
 
-        invalid_parameters = []
         _invalid_parameters = d.pop("invalid_parameters", UNSET)
-        for invalid_parameters_item_data in _invalid_parameters or []:
-            invalid_parameters_item = Problem.from_dict(invalid_parameters_item_data)
+        invalid_parameters: list[Problem] | Unset = UNSET
+        if _invalid_parameters is not UNSET:
+            invalid_parameters = []
+            for invalid_parameters_item_data in _invalid_parameters:
+                invalid_parameters_item = Problem.from_dict(invalid_parameters_item_data)
 
-            invalid_parameters.append(invalid_parameters_item)
+                invalid_parameters.append(invalid_parameters_item)
 
         missing_parameters = cast(list[str], d.pop("missing_parameters", UNSET))
 

--- a/openapi_python_client/templates/property_templates/list_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/list_property.py.jinja
@@ -3,15 +3,21 @@
 {% import "property_templates/" + inner_property.template as inner_template %}
 {% if inner_template.construct %}
 {% set inner_source = inner_property.python_name + "_data" %}
+{% if property.required %}
 {{ property.python_name }} = []
 _{{ property.python_name }} = {{ source }}
-{% if property.required %}
 for {{ inner_source }} in (_{{ property.python_name }}):
-{% else %}
-for {{ inner_source }} in (_{{ property.python_name }} or []):
-{% endif %}
     {{ inner_template.construct(inner_property, inner_source) | indent(4) }}
     {{ property.python_name }}.append({{ inner_property.python_name }})
+{% else %}
+_{{ property.python_name }} = {{ source }}
+{{ property.python_name }}: {{ property.get_type_string() }} = UNSET
+if _{{ property.python_name }} is not UNSET:
+    {{ property.python_name }} = []
+    for {{ inner_source }} in _{{ property.python_name }}:
+        {{ inner_template.construct(inner_property, inner_source) | indent(8) }}
+        {{ property.python_name }}.append({{ inner_property.python_name }})
+{% endif %}
 {% else %}
 {{ property.python_name }} = cast({{ property.get_type_string(no_optional=True) }}, {{ source }})
 {% endif %}


### PR DESCRIPTION
## Summary
Optional list properties were being incorrectly initialized with empty lists `[]` instead of `UNSET` when calling `from_dict()` with missing values. This breaks the semantic distinction between an omitted field and a field explicitly set to an empty list, which matters for PATCH operations and APIs that treat these cases differently.

## Changes
The fix modifies the `list_property.py.jinja` template to:
- Initialize optional list properties as UNSET with proper type annotations
- Only create and populate lists when the source value is not UNSET
- Preserve existing behavior for required list properties

## Test Plan
- All existing tests pass (417 tests)
- Updated golden record snapshots to reflect the corrected behavior
- Changes are minimal and focused on optional list properties only

Fixes #1305
Fixes #961