### PR TITLE
fix: Sort lazy imports to increase stability of generated code

### DIFF
--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -16,7 +16,7 @@ from ..types import UNSET, Unset
 {{ relative }}
 {% endfor %}
 
-{% for lazy_import in model.lazy_imports %}
+{% for lazy_import in model.lazy_imports | sort %}
 {% if loop.first %}
 if TYPE_CHECKING:
 {% endif %}
@@ -173,7 +173,7 @@ return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-    {% for lazy_import in model.lazy_imports %}
+    {% for lazy_import in model.lazy_imports | sort %}
         {{ lazy_import }}
     {% endfor %}
 {% if (model.required_properties or model.optional_properties or model.additional_properties) %}


### PR DESCRIPTION
Lazy imports of models aren't sorted, which causes them to be unstable and change from run to run. This is distracting in situations where you have a CI action automatically generating an API client and passing it as a PR to another repo.

This PR fixes this.