### PR TITLE
fix: sort remaining lazy imports in model template

### DIFF
--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -144,14 +144,14 @@ return field_dict
 {% endmacro %}
 
     def to_dict(self) -> dict[str, Any]:
-    {% for lazy_import in model.lazy_imports %}
+    {% for lazy_import in model.lazy_imports | sort %}
         {{ lazy_import }}
     {% endfor %}
         {{ _to_dict() | indent(8) }}
 
 {% if model.is_multipart_body %}
     def to_multipart(self) -> types.RequestFiles:
-    {% for lazy_import in model.lazy_imports %}
+    {% for lazy_import in model.lazy_imports | sort %}
         {{ lazy_import }}
     {% endfor %}
         files: types.RequestFiles = []
@@ -204,7 +204,7 @@ return field_dict
         {% import "property_templates/" + model.additional_properties.template as prop_template %}
 
 {% if model.additional_properties.lazy_imports %}
-    {% for lazy_import in model.additional_properties.lazy_imports %}
+    {% for lazy_import in model.additional_properties.lazy_imports | sort %}
         {{ lazy_import }}
     {% endfor %}
 {% endif %}

--- a/tests/test_templates/test_model_template.py
+++ b/tests/test_templates/test_model_template.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _section(content: str, start: str, end: str | None = None) -> str:
+    section = content.split(start, 1)[1]
+    if end is not None:
+        section = section.split(end, 1)[0]
+    return section
+
+
+def test_model_template_renders_lazy_imports_in_stable_order(env) -> None:
+    template = env.get_template("model.py.jinja")
+
+    model = SimpleNamespace(
+        is_multipart_body=True,
+        relative_imports=set(),
+        lazy_imports={"from ..models.z import Z", "from ..models.a import A"},
+        additional_properties=False,
+        class_info=SimpleNamespace(name="MyModel", module_name="my_model"),
+        title="",
+        description="",
+        example="",
+        required_properties=[],
+        optional_properties=[],
+    )
+    config = SimpleNamespace(docstrings_on_attributes=False)
+
+    content = template.render(model=model, config=config)
+
+    sections = [
+        _section(content, "if TYPE_CHECKING:", "T = TypeVar"),
+        _section(content, "def to_dict(self)", "def to_multipart(self)"),
+        _section(content, "def to_multipart(self)", "@classmethod"),
+        _section(content, "def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:", "return my_model"),
+    ]
+    for section in sections:
+        assert section.index("from ..models.a import A") < section.index("from ..models.z import Z")


### PR DESCRIPTION
In [this PR](https://github.com/openapi-generators/openapi-python-client/pull/1378) sorting of lazy imports was added. 

I fixed the remaining issues and verified with a test. It would be super nice to have deterministic generated code.