### PR TITLE
Add the `deprecated` attribute to `Endpoint` class

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -141,6 +141,7 @@ class Endpoint:
     requires_security: bool
     tags: list[PythonIdentifier]
     summary: str | None = ""
+    deprecated: bool = False
     relative_imports: set[str] = field(default_factory=set)
     query_parameters: list[Property] = field(default_factory=list)
     path_parameters: list[Property] = field(default_factory=list)
@@ -422,6 +423,7 @@ class Endpoint:
             name=name,
             requires_security=bool(data.security),
             tags=tags,
+            deprecated=data.deprecated,
         )
 
         result, schemas, parameters = Endpoint.add_parameters(

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -555,6 +555,38 @@ class TestEndpoint:
             config=config,
         )
 
+    def test_from_data_deprecated(self, mocker, config):
+        path = mocker.MagicMock()
+        method = mocker.MagicMock()
+        add_parameters = mocker.patch.object(
+            Endpoint, "add_parameters", return_value=(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+        )
+        mocker.patch.object(Endpoint, "_add_responses", return_value=(mocker.MagicMock(), mocker.MagicMock()))
+        data = oai.Operation.model_construct(
+            description=mocker.MagicMock(),
+            operationId=mocker.MagicMock(),
+            security={"blah": "bloo"},
+            responses=mocker.MagicMock(),
+            deprecated=True,
+        )
+        mocker.patch("openapi_python_client.utils.remove_string_escapes", return_value=data.description)
+
+        Endpoint.from_data(
+            data=data,
+            path=path,
+            method=method,
+            tags=["default"],
+            schemas=mocker.MagicMock(),
+            responses={},
+            parameters=mocker.MagicMock(),
+            config=config,
+            request_bodies={},
+        )
+
+        add_parameters.assert_called_once()
+        endpoint_arg = add_parameters.call_args.kwargs["endpoint"]
+        assert endpoint_arg.deprecated is True
+
     def test_from_data_some_bad_bodies(self, config):
         endpoint, _, _ = Endpoint.from_data(
             data=oai.Operation(


### PR DESCRIPTION
Currently, the `deprecated` field from the OpenAPI schema's Operation is not passed through to the `Endpoint` dataclass that templates use. The Operation schema does parse it ([operation.py#31](https://github.com/openapi-generators/openapi-python-client/blob/75cb057e19de30f745eb0831d8e9e9fb7f9e0378/openapi_python_client/schema/openapi_schema_pydantic/operation.py#L31)), but the Endpoint dataclass ([`openapi.py#L132-L152`](https://github.com/openapi-generators/openapi-python-client/blob/75cb057e19de30f745eb0831d8e9e9fb7f9e0378/openapi_python_client/parser/openapi.py#L132-L151)) doesn't include it, and it's not set during construction. This PR adds this field to the `Endpoint` class.

Fixes https://github.com/openapi-generators/openapi-python-client/issues/1412