### PR TITLE
feat: Add per-request headers, timeout, and auth overrides to endpoint functions

### DIFF
--- a/.changeset/add_per_request_headers_timeout_auth_overrides.md
+++ b/.changeset/add_per_request_headers_timeout_auth_overrides.md
@@ -1,0 +1,15 @@
+---
+default: minor
+---
+
+# Add per-request headers, timeout, and auth overrides to endpoint functions
+
+All generated endpoint functions (`sync_detailed`, `asyncio_detailed`, `sync`, `asyncio`) now accept three optional keyword arguments forwarded directly to the underlying httpx request:
+
+- `headers: dict[str, str] | None = None` — extra headers merged on top of any spec-defined headers for this request
+- `timeout: httpx.Timeout | None | Unset = UNSET` — override the client-level timeout for this request; `None` disables the timeout
+- `auth: httpx.Auth | None | Unset = UNSET` — override the client-level auth for this request; `None` disables auth
+
+This allows per-request customisation without creating a new client instance, preserving the shared httpx connection pool. Using `with_headers()` / `with_timeout()` at runtime was previously the only option, but those methods mutate the original client's underlying httpx client as a side effect and cause the returned client to open a new connection pool on first use—making them unsafe for concurrent async code.
+
+Note: client-level headers cannot be fully removed for a single request via this mechanism, only overridden with a different value.

--- a/end_to_end_tests/functional_tests/generated_code_execution/test_request_overrides.py
+++ b/end_to_end_tests/functional_tests/generated_code_execution/test_request_overrides.py
@@ -1,0 +1,138 @@
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from end_to_end_tests.functional_tests.helpers import (
+    with_generated_client_fixture,
+    with_generated_code_import,
+)
+
+
+SIMPLE_SPEC = """
+paths:
+  "/items":
+    get:
+      operationId: getItems
+      responses:
+        "200":
+          description: Success
+"""
+
+SPEC_WITH_HEADER_PARAM = """
+paths:
+  "/items":
+    get:
+      operationId: getItems
+      parameters:
+        - name: X-Request-Id
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Success
+"""
+
+
+def _make_mock_client(Client):
+    mock_httpx_client = MagicMock(spec=httpx.Client)
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.content = b""
+    mock_response.headers = {}
+    mock_httpx_client.request.return_value = mock_response
+    client = Client(base_url="https://api.example.com")
+    client.set_httpx_client(mock_httpx_client)
+    return client, mock_httpx_client
+
+
+@with_generated_client_fixture(SIMPLE_SPEC)
+@with_generated_code_import(".api.default.get_items.sync_detailed")
+@with_generated_code_import(".client.Client")
+class TestPerRequestHeaders:
+    def test_extra_headers_are_forwarded(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, headers={"X-Trace-Id": "abc123"})
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["headers"]["X-Trace-Id"] == "abc123"
+
+    def test_omitting_headers_does_not_inject_headers_key(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client)
+        call_kwargs = mock_httpx.request.call_args[1]
+        # No spec-defined headers and no override — headers key should be absent
+        assert "headers" not in call_kwargs
+
+    def test_multiple_extra_headers_are_all_forwarded(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, headers={"X-A": "1", "X-B": "2"})
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["headers"]["X-A"] == "1"
+        assert call_kwargs["headers"]["X-B"] == "2"
+
+
+@with_generated_client_fixture(SPEC_WITH_HEADER_PARAM)
+@with_generated_code_import(".api.default.get_items.sync_detailed")
+@with_generated_code_import(".client.Client")
+class TestPerRequestHeadersWithSpecHeaders:
+    def test_caller_header_overrides_spec_header(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, x_request_id="spec-value", headers={"X-Request-Id": "override"})
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["headers"]["X-Request-Id"] == "override"
+
+    def test_caller_headers_merged_with_spec_headers(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, x_request_id="spec-value", headers={"X-Extra": "extra"})
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["headers"]["X-Request-Id"] == "spec-value"
+        assert call_kwargs["headers"]["X-Extra"] == "extra"
+
+
+@with_generated_client_fixture(SIMPLE_SPEC)
+@with_generated_code_import(".api.default.get_items.sync_detailed")
+@with_generated_code_import(".client.Client")
+class TestPerRequestTimeout:
+    def test_timeout_override_is_forwarded(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, timeout=httpx.Timeout(120.0))
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["timeout"] == httpx.Timeout(120.0)
+
+    def test_timeout_none_disables_timeout(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, timeout=None)
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["timeout"] is None
+
+    def test_omitting_timeout_does_not_inject_timeout_key(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client)
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert "timeout" not in call_kwargs
+
+
+@with_generated_client_fixture(SIMPLE_SPEC)
+@with_generated_code_import(".api.default.get_items.sync_detailed")
+@with_generated_code_import(".client.Client")
+class TestPerRequestAuth:
+    def test_auth_override_is_forwarded(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        auth = httpx.BasicAuth("user", "pass")
+        sync_detailed(client=client, auth=auth)
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["auth"] is auth
+
+    def test_auth_none_disables_auth(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client, auth=None)
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert call_kwargs["auth"] is None
+
+    def test_omitting_auth_does_not_inject_auth_key(self, sync_detailed, Client):
+        client, mock_httpx = _make_mock_client(Client)
+        sync_detailed(client=client)
+        call_kwargs = mock_httpx.request.call_args[1]
+        assert "auth" not in call_kwargs

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/json_like.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/json_like.py
@@ -52,6 +52,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: JsonLikeBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """A content type that works like json but isn't application/json
 
@@ -69,6 +72,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -81,6 +90,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: JsonLikeBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """A content type that works like json but isn't application/json
 
@@ -98,6 +110,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/optional_body.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/optional_body.py
@@ -52,6 +52,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: OptionalBodyBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test optional request body
 
@@ -69,6 +72,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -81,6 +90,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: OptionalBodyBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test optional request body
 
@@ -98,6 +110,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/post_bodies_multiple.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/post_bodies_multiple.py
@@ -70,6 +70,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodiesMultipleJsonBody | File | PostBodiesMultipleDataBody | PostBodiesMultipleFilesBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test multiple bodies
 
@@ -90,6 +93,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -102,6 +111,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodiesMultipleJsonBody | File | PostBodiesMultipleDataBody | PostBodiesMultipleFilesBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test multiple bodies
 
@@ -122,6 +134,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/bodies/refs.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/bodies/refs.py
@@ -52,6 +52,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test request body defined via ref
 
@@ -69,6 +72,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -81,6 +90,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test request body defined via ref
 
@@ -98,6 +110,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/config/content_type_override.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/config/content_type_override.py
@@ -52,6 +52,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Content Type Override
 
@@ -69,6 +72,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -81,6 +90,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Content Type Override
 
@@ -98,6 +110,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -105,6 +120,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Content Type Override
 
@@ -122,6 +140,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -132,6 +156,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Content Type Override
 
@@ -150,5 +177,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_common_parameters.py
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     common: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -67,6 +70,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         common=common,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -79,6 +88,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     common: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -95,6 +107,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         common=common,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_allof.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_allof.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.get_models_allof_response_200 import GetModelsAllofResponse200
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -47,6 +47,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[GetModelsAllofResponse200]:
     """
     Raises:
@@ -58,6 +61,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -69,6 +78,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> GetModelsAllofResponse200 | None:
     """
     Raises:
@@ -81,12 +93,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[GetModelsAllofResponse200]:
     """
     Raises:
@@ -98,6 +116,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -107,6 +131,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> GetModelsAllofResponse200 | None:
     """
     Raises:
@@ -120,5 +147,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_oneof_with_required_const.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/get_models_oneof_with_required_const.py
@@ -11,7 +11,7 @@ from ...models.get_models_oneof_with_required_const_response_200_type_0 import (
 from ...models.get_models_oneof_with_required_const_response_200_type_1 import (
     GetModelsOneofWithRequiredConstResponse200Type1,
 )
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -70,6 +70,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[GetModelsOneofWithRequiredConstResponse200Type0 | GetModelsOneofWithRequiredConstResponse200Type1]:
     """
     Raises:
@@ -81,6 +84,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -92,6 +101,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> GetModelsOneofWithRequiredConstResponse200Type0 | GetModelsOneofWithRequiredConstResponse200Type1 | None:
     """
     Raises:
@@ -104,12 +116,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[GetModelsOneofWithRequiredConstResponse200Type0 | GetModelsOneofWithRequiredConstResponse200Type1]:
     """
     Raises:
@@ -121,6 +139,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -130,6 +154,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> GetModelsOneofWithRequiredConstResponse200Type0 | GetModelsOneofWithRequiredConstResponse200Type1 | None:
     """
     Raises:
@@ -143,5 +170,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_common_parameters.py
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     common: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -67,6 +70,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         common=common,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -79,6 +88,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     common: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -95,6 +107,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         common=common,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/post_types_unions_duplicate_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/post_types_unions_duplicate_types.py
@@ -62,6 +62,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[AModel]:
     """
     Args:
@@ -78,6 +81,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -90,6 +99,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> AModel | None:
     """
     Args:
@@ -106,6 +118,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -113,6 +128,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[AModel]:
     """
     Args:
@@ -129,6 +147,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -139,6 +163,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: AModel | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> AModel | None:
     """
     Args:
@@ -156,5 +183,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/default/reserved_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/default/reserved_parameters.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -55,6 +55,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     client_query: str,
     url_query: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -73,6 +76,12 @@ def sync_detailed(
         client_query=client_query,
         url_query=url_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -86,6 +95,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     client_query: str,
     url_query: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -104,6 +116,12 @@ async def asyncio_detailed(
         client_query=client_query,
         url_query=url_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/defaults/defaults_tests_defaults_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/defaults/defaults_tests_defaults_post.py
@@ -132,6 +132,9 @@ def sync_detailed(
     enum_prop: AnEnum,
     model_prop: ModelWithUnionProperty,
     required_model_prop: ModelWithUnionProperty,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Defaults
 
@@ -173,6 +176,12 @@ def sync_detailed(
         model_prop=model_prop,
         required_model_prop=required_model_prop,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -197,6 +206,9 @@ def sync(
     enum_prop: AnEnum,
     model_prop: ModelWithUnionProperty,
     required_model_prop: ModelWithUnionProperty,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Defaults
 
@@ -238,6 +250,9 @@ def sync(
         enum_prop=enum_prop,
         model_prop=model_prop,
         required_model_prop=required_model_prop,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -257,6 +272,9 @@ async def asyncio_detailed(
     enum_prop: AnEnum,
     model_prop: ModelWithUnionProperty,
     required_model_prop: ModelWithUnionProperty,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Defaults
 
@@ -298,6 +316,12 @@ async def asyncio_detailed(
         model_prop=model_prop,
         required_model_prop=required_model_prop,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -320,6 +344,9 @@ async def asyncio(
     enum_prop: AnEnum,
     model_prop: ModelWithUnionProperty,
     required_model_prop: ModelWithUnionProperty,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Defaults
 
@@ -362,5 +389,8 @@ async def asyncio(
             enum_prop=enum_prop,
             model_prop=model_prop,
             required_model_prop=required_model_prop,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/enums/bool_enum_tests_bool_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/enums/bool_enum_tests_bool_enum_post.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     bool_enum: bool,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Bool Enum
 
@@ -68,6 +71,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         bool_enum=bool_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -80,6 +89,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     bool_enum: bool,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Bool Enum
 
@@ -97,6 +109,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         bool_enum=bool_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/enums/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/enums/int_enum_tests_int_enum_post.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.an_int_enum import AnIntEnum
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -53,6 +53,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     int_enum: AnIntEnum,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Int Enum
 
@@ -70,6 +73,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         int_enum=int_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -82,6 +91,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     int_enum: AnIntEnum,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Int Enum
 
@@ -99,6 +111,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         int_enum=int_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_header_types.py
@@ -75,6 +75,9 @@ def sync_detailed(
     integer_header: int | Unset = UNSET,
     int_enum_header: GetLocationHeaderTypesIntEnumHeader | Unset = UNSET,
     string_enum_header: GetLocationHeaderTypesStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -101,6 +104,12 @@ def sync_detailed(
         int_enum_header=int_enum_header,
         string_enum_header=string_enum_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -118,6 +127,9 @@ async def asyncio_detailed(
     integer_header: int | Unset = UNSET,
     int_enum_header: GetLocationHeaderTypesIntEnumHeader | Unset = UNSET,
     string_enum_header: GetLocationHeaderTypesStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -144,6 +156,12 @@ async def asyncio_detailed(
         int_enum_header=int_enum_header,
         string_enum_header=string_enum_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/location/get_location_query_optionality.py
@@ -80,6 +80,9 @@ def sync_detailed(
     null_required: datetime.datetime | None,
     null_not_required: datetime.datetime | None | Unset = UNSET,
     not_null_not_required: datetime.datetime | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -102,6 +105,12 @@ def sync_detailed(
         null_not_required=null_not_required,
         not_null_not_required=not_null_not_required,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -117,6 +126,9 @@ async def asyncio_detailed(
     null_required: datetime.datetime | None,
     null_not_required: datetime.datetime | None | Unset = UNSET,
     not_null_not_required: datetime.datetime | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -139,6 +151,12 @@ async def asyncio_detailed(
         null_not_required=null_not_required,
         not_null_not_required=not_null_not_required,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/hyphen_in_path.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/hyphen_in_path.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -46,6 +46,9 @@ def sync_detailed(
     hyphen_in_path: str,
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -62,6 +65,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         hyphen_in_path=hyphen_in_path,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -74,6 +83,9 @@ async def asyncio_detailed(
     hyphen_in_path: str,
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -90,6 +102,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         hyphen_in_path=hyphen_in_path,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/mixed_case.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/mixed_case.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.mixed_case_response_200 import MixedCaseResponse200
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -60,6 +60,9 @@ def sync_detailed(
     client: AuthenticatedClient | Client,
     mixed_case: str,
     mixedCase: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[MixedCaseResponse200]:
     """
     Args:
@@ -78,6 +81,12 @@ def sync_detailed(
         mixed_case=mixed_case,
         mixedCase=mixedCase,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -91,6 +100,9 @@ def sync(
     client: AuthenticatedClient | Client,
     mixed_case: str,
     mixedCase: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> MixedCaseResponse200 | None:
     """
     Args:
@@ -109,6 +121,9 @@ def sync(
         client=client,
         mixed_case=mixed_case,
         mixedCase=mixedCase,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -117,6 +132,9 @@ async def asyncio_detailed(
     client: AuthenticatedClient | Client,
     mixed_case: str,
     mixedCase: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[MixedCaseResponse200]:
     """
     Args:
@@ -135,6 +153,12 @@ async def asyncio_detailed(
         mixed_case=mixed_case,
         mixedCase=mixedCase,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -146,6 +170,9 @@ async def asyncio(
     client: AuthenticatedClient | Client,
     mixed_case: str,
     mixedCase: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> MixedCaseResponse200 | None:
     """
     Args:
@@ -165,5 +192,8 @@ async def asyncio(
             client=client,
             mixed_case=mixed_case,
             mixedCase=mixedCase,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/naming/post_naming_property_conflict_with_import.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/naming/post_naming_property_conflict_with_import.py
@@ -61,6 +61,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostNamingPropertyConflictWithImportBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostNamingPropertyConflictWithImportResponse200]:
     """
     Args:
@@ -77,6 +80,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,6 +98,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: PostNamingPropertyConflictWithImportBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostNamingPropertyConflictWithImportResponse200 | None:
     """
     Args:
@@ -105,6 +117,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -112,6 +127,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostNamingPropertyConflictWithImportBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostNamingPropertyConflictWithImportResponse200]:
     """
     Args:
@@ -128,6 +146,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -138,6 +162,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: PostNamingPropertyConflictWithImportBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostNamingPropertyConflictWithImportResponse200 | None:
     """
     Args:
@@ -155,5 +182,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameter_references/get_parameter_references_path_param.py
@@ -73,6 +73,9 @@ def sync_detailed(
     integer_param: int | Unset = 0,
     header_param: None | str | Unset = UNSET,
     cookie_param: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test different types of parameter references
 
@@ -98,6 +101,12 @@ def sync_detailed(
         header_param=header_param,
         cookie_param=cookie_param,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -114,6 +123,9 @@ async def asyncio_detailed(
     integer_param: int | Unset = 0,
     header_param: None | str | Unset = UNSET,
     cookie_param: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test different types of parameter references
 
@@ -139,6 +151,12 @@ async def asyncio_detailed(
         header_param=header_param,
         cookie_param=cookie_param,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/delete_common_parameters_overriding_param.py
@@ -56,6 +56,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     param_query: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -74,6 +77,12 @@ def sync_detailed(
         param_path=param_path,
         param_query=param_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -87,6 +96,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     param_query: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -105,6 +117,12 @@ async def asyncio_detailed(
         param_path=param_path,
         param_query=param_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_common_parameters_overriding_param.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -56,6 +56,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     param_query: str = "overridden_in_GET",
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test that if you have an overriding property from `PathItem` in `Operation`, it produces valid code
 
@@ -76,6 +79,12 @@ def sync_detailed(
         param_path=param_path,
         param_query=param_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,6 +98,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     param_query: str = "overridden_in_GET",
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Test that if you have an overriding property from `PathItem` in `Operation`, it produces valid code
 
@@ -109,6 +121,12 @@ async def asyncio_detailed(
         param_path=param_path,
         param_query=param_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/get_same_name_multiple_locations_param.py
@@ -69,6 +69,9 @@ def sync_detailed(
     param_query: str | Unset = UNSET,
     param_header: str | Unset = UNSET,
     param_cookie: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -91,6 +94,12 @@ def sync_detailed(
         param_header=param_header,
         param_cookie=param_cookie,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -106,6 +115,9 @@ async def asyncio_detailed(
     param_query: str | Unset = UNSET,
     param_header: str | Unset = UNSET,
     param_cookie: str | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -128,6 +140,12 @@ async def asyncio_detailed(
         param_header=param_header,
         param_cookie=param_cookie,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/parameters/multiple_path_parameters.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -55,6 +55,9 @@ def sync_detailed(
     param3: int,
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -77,6 +80,12 @@ def sync_detailed(
         param1=param1,
         param3=param3,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -92,6 +101,9 @@ async def asyncio_detailed(
     param3: int,
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -114,6 +126,12 @@ async def asyncio_detailed(
         param1=param1,
         param3=param3,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/default_status_code.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/default_status_code.py
@@ -4,7 +4,7 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -34,6 +34,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Default Status Code Only
 
@@ -46,6 +49,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -57,6 +66,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Default Status Code Only
 
@@ -70,12 +82,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Default Status Code Only
 
@@ -88,6 +106,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -97,6 +121,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Default Status Code Only
 
@@ -111,5 +138,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/post_responses_unions_simple_before_complex.py
@@ -8,7 +8,7 @@ from ...client import AuthenticatedClient, Client
 from ...models.post_responses_unions_simple_before_complex_response_200 import (
     PostResponsesUnionsSimpleBeforeComplexResponse200,
 )
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -49,6 +49,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
@@ -61,6 +64,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -72,6 +81,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostResponsesUnionsSimpleBeforeComplexResponse200 | None:
     """Regression test for #603
 
@@ -85,12 +97,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostResponsesUnionsSimpleBeforeComplexResponse200]:
     """Regression test for #603
 
@@ -103,6 +121,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -112,6 +136,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostResponsesUnionsSimpleBeforeComplexResponse200 | None:
     """Regression test for #603
 
@@ -126,5 +153,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/reference_response.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/reference_response.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.a_model import AModel
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -43,6 +43,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[AModel]:
     """Endpoint using predefined response
 
@@ -55,6 +58,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -66,6 +75,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> AModel | None:
     """Endpoint using predefined response
 
@@ -79,12 +91,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[AModel]:
     """Endpoint using predefined response
 
@@ -97,6 +115,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -106,6 +130,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> AModel | None:
     """Endpoint using predefined response
 
@@ -120,5 +147,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/status_code_patterns.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/status_code_patterns.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.status_code_patterns_response_2xx import StatusCodePatternsResponse2XX
 from ...models.status_code_patterns_response_4xx import StatusCodePatternsResponse4XX
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -53,6 +53,9 @@ def _build_response(
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[StatusCodePatternsResponse2XX | StatusCodePatternsResponse4XX]:
     """Status Code Patterns
 
@@ -65,6 +68,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -76,6 +85,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> StatusCodePatternsResponse2XX | StatusCodePatternsResponse4XX | None:
     """Status Code Patterns
 
@@ -89,12 +101,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[StatusCodePatternsResponse2XX | StatusCodePatternsResponse4XX]:
     """Status Code Patterns
 
@@ -107,6 +125,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -116,6 +140,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> StatusCodePatternsResponse2XX | StatusCodePatternsResponse4XX | None:
     """Status Code Patterns
 
@@ -130,5 +157,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/status_code_precedence.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/status_code_precedence.py
@@ -4,7 +4,7 @@ from typing import Any
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -46,6 +46,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Status Codes Precedence
 
@@ -60,6 +63,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -71,6 +80,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Status Codes Precedence
 
@@ -86,12 +98,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Status Codes Precedence
 
@@ -106,6 +124,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -115,6 +139,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Status Codes Precedence
 
@@ -131,5 +158,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/responses/text_response.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/responses/text_response.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -41,6 +41,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Text Response
 
@@ -53,6 +56,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -64,6 +73,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Text Response
 
@@ -77,12 +89,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """Text Response
 
@@ -95,6 +113,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -104,6 +128,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """Text Response
 
@@ -118,5 +145,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag1/get_tag_with_number.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -40,6 +40,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Raises:
@@ -51,6 +54,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -62,6 +71,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Raises:
@@ -73,6 +85,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tag2/get_tag_with_number.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tag2/get_tag_with_number.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -40,6 +40,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Raises:
@@ -51,6 +54,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -62,6 +71,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Raises:
@@ -73,6 +85,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/callback_test.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.a_model import AModel
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -62,6 +62,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Path with callback
 
@@ -81,6 +84,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -93,6 +102,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Path with callback
 
@@ -112,6 +124,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -119,6 +134,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Path with callback
 
@@ -138,6 +156,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -148,6 +172,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Path with callback
 
@@ -168,5 +195,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/description_with_backslash.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -40,6 +40,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     r""" Test description with \
 
@@ -54,6 +57,12 @@ def sync_detailed(
      """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -65,6 +74,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     r""" Test description with \
 
@@ -79,6 +91,12 @@ async def asyncio_detailed(
      """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_booleans.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -42,6 +42,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[bool]]:
     """Get Basic List Of Booleans
 
@@ -56,6 +59,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -67,6 +76,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[bool] | None:
     """Get Basic List Of Booleans
 
@@ -82,12 +94,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[bool]]:
     """Get Basic List Of Booleans
 
@@ -102,6 +120,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -111,6 +135,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[bool] | None:
     """Get Basic List Of Booleans
 
@@ -127,5 +154,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_floats.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -42,6 +42,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[float]]:
     """Get Basic List Of Floats
 
@@ -56,6 +59,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -67,6 +76,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[float] | None:
     """Get Basic List Of Floats
 
@@ -82,12 +94,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[float]]:
     """Get Basic List Of Floats
 
@@ -102,6 +120,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -111,6 +135,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[float] | None:
     """Get Basic List Of Floats
 
@@ -127,5 +154,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_integers.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -42,6 +42,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[int]]:
     """Get Basic List Of Integers
 
@@ -56,6 +59,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -67,6 +76,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[int] | None:
     """Get Basic List Of Integers
 
@@ -82,12 +94,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[int]]:
     """Get Basic List Of Integers
 
@@ -102,6 +120,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -111,6 +135,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[int] | None:
     """Get Basic List Of Integers
 
@@ -127,5 +154,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_basic_list_of_strings.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -42,6 +42,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[str]]:
     """Get Basic List Of Strings
 
@@ -56,6 +59,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -67,6 +76,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[str] | None:
     """Get Basic List Of Strings
 
@@ -82,12 +94,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[str]]:
     """Get Basic List Of Strings
 
@@ -102,6 +120,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -111,6 +135,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[str] | None:
     """Get Basic List Of Strings
 
@@ -127,5 +154,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/get_user_list.py
@@ -10,7 +10,7 @@ from ...models.a_model import AModel
 from ...models.an_enum import AnEnum
 from ...models.an_enum_with_null import AnEnumWithNull
 from ...models.http_validation_error import HTTPValidationError
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -111,6 +111,9 @@ def sync_detailed(
     an_enum_value_with_null: list[AnEnumWithNull | None],
     an_enum_value_with_only_null: list[None],
     some_date: datetime.date | datetime.datetime,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | list[AModel]]:
     """Get List
 
@@ -136,6 +139,12 @@ def sync_detailed(
         an_enum_value_with_only_null=an_enum_value_with_only_null,
         some_date=some_date,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -151,6 +160,9 @@ def sync(
     an_enum_value_with_null: list[AnEnumWithNull | None],
     an_enum_value_with_only_null: list[None],
     some_date: datetime.date | datetime.datetime,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | list[AModel] | None:
     """Get List
 
@@ -176,6 +188,9 @@ def sync(
         an_enum_value_with_null=an_enum_value_with_null,
         an_enum_value_with_only_null=an_enum_value_with_only_null,
         some_date=some_date,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -186,6 +201,9 @@ async def asyncio_detailed(
     an_enum_value_with_null: list[AnEnumWithNull | None],
     an_enum_value_with_only_null: list[None],
     some_date: datetime.date | datetime.datetime,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | list[AModel]]:
     """Get List
 
@@ -211,6 +229,12 @@ async def asyncio_detailed(
         an_enum_value_with_only_null=an_enum_value_with_only_null,
         some_date=some_date,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -224,6 +248,9 @@ async def asyncio(
     an_enum_value_with_null: list[AnEnumWithNull | None],
     an_enum_value_with_only_null: list[None],
     some_date: datetime.date | datetime.datetime,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | list[AModel] | None:
     """Get List
 
@@ -250,5 +277,8 @@ async def asyncio(
             an_enum_value_with_null=an_enum_value_with_null,
             an_enum_value_with_only_null=an_enum_value_with_only_null,
             some_date=some_date,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/json_body_tests_json_body_post.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.a_model import AModel
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -62,6 +62,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Json Body
 
@@ -81,6 +84,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -93,6 +102,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Json Body
 
@@ -112,6 +124,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -119,6 +134,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Json Body
 
@@ -138,6 +156,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -148,6 +172,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: AModel,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Json Body
 
@@ -168,5 +195,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/no_response_tests_no_response_get.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -40,6 +40,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """No Response
 
@@ -52,6 +55,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -63,6 +72,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """No Response
 
@@ -75,6 +87,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_get.py
@@ -6,7 +6,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import File, Response
+from ...types import UNSET, File, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -43,6 +43,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[File]:
     """Octet Stream
 
@@ -55,6 +58,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -66,6 +75,9 @@ def sync_detailed(
 def sync(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> File | None:
     """Octet Stream
 
@@ -79,12 +91,18 @@ def sync(
 
     return sync_detailed(
         client=client,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[File]:
     """Octet Stream
 
@@ -97,6 +115,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -106,6 +130,9 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> File | None:
     """Octet Stream
 
@@ -120,5 +147,8 @@ async def asyncio(
     return (
         await asyncio_detailed(
             client=client,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/octet_stream_tests_octet_stream_post.py
@@ -64,6 +64,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: File | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | OctetStreamTestsOctetStreamPostResponse200]:
     """Binary (octet stream) request body
 
@@ -81,6 +84,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -93,6 +102,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: File | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | OctetStreamTestsOctetStreamPostResponse200 | None:
     """Binary (octet stream) request body
 
@@ -110,6 +122,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -117,6 +132,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: File | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | OctetStreamTestsOctetStreamPostResponse200]:
     """Binary (octet stream) request body
 
@@ -134,6 +152,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -144,6 +168,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: File | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | OctetStreamTestsOctetStreamPostResponse200 | None:
     """Binary (octet stream) request body
 
@@ -162,5 +189,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.a_form_data import AFormData
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AFormData,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Post form data
 
@@ -70,6 +73,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -82,6 +91,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: AFormData,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Post form data
 
@@ -101,6 +113,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_form_data_inline.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_form_data_inline_body import PostFormDataInlineBody
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostFormDataInlineBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Post form data (inline schema)
 
@@ -70,6 +73,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -82,6 +91,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostFormDataInlineBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Post form data (inline schema)
 
@@ -101,6 +113,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/post_tests_json_body_string.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -61,6 +61,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | str]:
     """Json Body Which is String
 
@@ -78,6 +81,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -90,6 +99,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | str | None:
     """Json Body Which is String
 
@@ -107,6 +119,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -114,6 +129,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | str]:
     """Json Body Which is String
 
@@ -131,6 +149,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -141,6 +165,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> HTTPValidationError | str | None:
     """Json Body Which is String
 
@@ -159,5 +186,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/test_inline_objects.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.test_inline_objects_body import TestInlineObjectsBody
 from ...models.test_inline_objects_response_200 import TestInlineObjectsResponse200
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -58,6 +58,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: TestInlineObjectsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[TestInlineObjectsResponse200]:
     """Test Inline Objects
 
@@ -75,6 +78,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -87,6 +96,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: TestInlineObjectsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> TestInlineObjectsResponse200 | None:
     """Test Inline Objects
 
@@ -104,6 +116,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -111,6 +126,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: TestInlineObjectsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[TestInlineObjectsResponse200]:
     """Test Inline Objects
 
@@ -128,6 +146,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -138,6 +162,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: TestInlineObjectsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> TestInlineObjectsResponse200 | None:
     """Test Inline Objects
 
@@ -156,5 +183,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/token_with_cookie_auth_token_with_cookie_get.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     my_token: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """TOKEN_WITH_COOKIE
 
@@ -70,6 +73,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         my_token=my_token,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -82,6 +91,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     my_token: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """TOKEN_WITH_COOKIE
 
@@ -101,6 +113,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         my_token=my_token,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/unsupported_content_tests_unsupported_content_get.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs() -> dict[str, Any]:
@@ -40,6 +40,9 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Unsupported Content
 
@@ -52,6 +55,12 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -63,6 +72,9 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Unsupported Content
 
@@ -75,6 +87,12 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs()
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/tests/upload_file_tests_upload_post.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.body_upload_file_tests_upload_post import BodyUploadFileTestsUploadPost
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -60,6 +60,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: BodyUploadFileTestsUploadPost,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Upload File
 
@@ -79,6 +82,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -91,6 +100,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: BodyUploadFileTestsUploadPost,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Upload File
 
@@ -110,6 +122,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -117,6 +132,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: BodyUploadFileTestsUploadPost,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Upload File
 
@@ -136,6 +154,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -146,6 +170,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: BodyUploadFileTestsUploadPost,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Upload File
 
@@ -166,5 +193,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
+++ b/end_to_end_tests/golden-record/my_test_api_client/api/true_/false_.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     import_: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -67,6 +70,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         import_=import_,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -79,6 +88,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     import_: str,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """
     Args:
@@ -95,6 +107,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         import_=import_,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/bool_enum_tests_bool_enum_post.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/bool_enum_tests_bool_enum_post.py
@@ -5,7 +5,7 @@ import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -51,6 +51,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     bool_enum: bool,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Bool Enum
 
@@ -68,6 +71,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         bool_enum=bool_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -80,6 +89,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     bool_enum: bool,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Bool Enum
 
@@ -97,6 +109,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         bool_enum=bool_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/int_enum_tests_int_enum_post.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/enums/int_enum_tests_int_enum_post.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.an_int_enum import AnIntEnum
-from ...types import UNSET, Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -53,6 +53,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     int_enum: AnIntEnum,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Int Enum
 
@@ -70,6 +73,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         int_enum=int_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -82,6 +91,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     int_enum: AnIntEnum,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Any]:
     """Int Enum
 
@@ -99,6 +111,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         int_enum=int_enum,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/get_user_list.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/get_user_list.py
@@ -100,6 +100,9 @@ def sync_detailed(
     an_enum_value_with_only_null: list[None],
     int_enum_header: GetUserListIntEnumHeader | Unset = UNSET,
     string_enum_header: GetUserListStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[AModel]]:
     """Get List
 
@@ -127,6 +130,12 @@ def sync_detailed(
         int_enum_header=int_enum_header,
         string_enum_header=string_enum_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -143,6 +152,9 @@ def sync(
     an_enum_value_with_only_null: list[None],
     int_enum_header: GetUserListIntEnumHeader | Unset = UNSET,
     string_enum_header: GetUserListStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[AModel] | None:
     """Get List
 
@@ -170,6 +182,9 @@ def sync(
         an_enum_value_with_only_null=an_enum_value_with_only_null,
         int_enum_header=int_enum_header,
         string_enum_header=string_enum_header,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -181,6 +196,9 @@ async def asyncio_detailed(
     an_enum_value_with_only_null: list[None],
     int_enum_header: GetUserListIntEnumHeader | Unset = UNSET,
     string_enum_header: GetUserListStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[AModel]]:
     """Get List
 
@@ -208,6 +226,12 @@ async def asyncio_detailed(
         int_enum_header=int_enum_header,
         string_enum_header=string_enum_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -222,6 +246,9 @@ async def asyncio(
     an_enum_value_with_only_null: list[None],
     int_enum_header: GetUserListIntEnumHeader | Unset = UNSET,
     string_enum_header: GetUserListStringEnumHeader | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[AModel] | None:
     """Get List
 
@@ -250,5 +277,8 @@ async def asyncio(
             an_enum_value_with_only_null=an_enum_value_with_only_null,
             int_enum_header=int_enum_header,
             string_enum_header=string_enum_header,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/post_user_list.py
+++ b/end_to_end_tests/literal-enums-golden-record/my_enum_api_client/api/tests/post_user_list.py
@@ -58,6 +58,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostUserListBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[AModel]]:
     """Post List
 
@@ -77,6 +80,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -89,6 +98,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: PostUserListBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[AModel] | None:
     """Post List
 
@@ -108,6 +120,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -115,6 +130,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostUserListBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[list[AModel]]:
     """Post List
 
@@ -134,6 +152,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -144,6 +168,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: PostUserListBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> list[AModel] | None:
     """Post List
 
@@ -164,5 +191,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/const/post_const_path.py
@@ -78,6 +78,9 @@ def sync_detailed(
     body: PostConstPathBody,
     required_query: Literal["this always goes in the query"],
     optional_query: Literal["this sometimes goes in the query"] | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Literal["Why have a fixed response? I dunno"]]:
     """
     Args:
@@ -100,6 +103,12 @@ def sync_detailed(
         required_query=required_query,
         optional_query=optional_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -115,6 +124,9 @@ def sync(
     body: PostConstPathBody,
     required_query: Literal["this always goes in the query"],
     optional_query: Literal["this sometimes goes in the query"] | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Literal["Why have a fixed response? I dunno"] | None:
     """
     Args:
@@ -137,6 +149,9 @@ def sync(
         body=body,
         required_query=required_query,
         optional_query=optional_query,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -147,6 +162,9 @@ async def asyncio_detailed(
     body: PostConstPathBody,
     required_query: Literal["this always goes in the query"],
     optional_query: Literal["this sometimes goes in the query"] | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[Literal["Why have a fixed response? I dunno"]]:
     """
     Args:
@@ -169,6 +187,12 @@ async def asyncio_detailed(
         required_query=required_query,
         optional_query=optional_query,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -182,6 +206,9 @@ async def asyncio(
     body: PostConstPathBody,
     required_query: Literal["this always goes in the query"],
     optional_query: Literal["this sometimes goes in the query"] | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Literal["Why have a fixed response? I dunno"] | None:
     """
     Args:
@@ -205,5 +232,8 @@ async def asyncio(
             body=body,
             required_query=required_query,
             optional_query=optional_query,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/post_prefix_items.py
+++ b/end_to_end_tests/test-3-1-golden-record/test_3_1_features_client/api/prefix_items/post_prefix_items.py
@@ -6,7 +6,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_prefix_items_body import PostPrefixItemsBody
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -52,6 +52,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostPrefixItemsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """
     Args:
@@ -68,6 +71,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -80,6 +89,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: PostPrefixItemsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """
     Args:
@@ -96,6 +108,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -103,6 +118,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostPrefixItemsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[str]:
     """
     Args:
@@ -119,6 +137,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -129,6 +153,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: PostPrefixItemsBody,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> str | None:
     """
     Args:
@@ -146,5 +173,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/integration-tests/integration_tests/api/body/post_body_multipart.py
+++ b/integration-tests/integration_tests/api/body/post_body_multipart.py
@@ -63,6 +63,9 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodyMultipartBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostBodyMultipartResponse200 | PublicError]:
     """
     Args:
@@ -79,6 +82,12 @@ def sync_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -91,6 +100,9 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodyMultipartBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostBodyMultipartResponse200 | PublicError | None:
     """
     Args:
@@ -107,6 +119,9 @@ def sync(
     return sync_detailed(
         client=client,
         body=body,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -114,6 +129,9 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodyMultipartBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostBodyMultipartResponse200 | PublicError]:
     """
     Args:
@@ -130,6 +148,12 @@ async def asyncio_detailed(
     kwargs = _get_kwargs(
         body=body,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -140,6 +164,9 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
     body: PostBodyMultipartBody | Unset = UNSET,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostBodyMultipartResponse200 | PublicError | None:
     """
     Args:
@@ -157,5 +184,8 @@ async def asyncio(
         await asyncio_detailed(
             client=client,
             body=body,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/integration-tests/integration_tests/api/parameters/post_parameters_header.py
+++ b/integration-tests/integration_tests/api/parameters/post_parameters_header.py
@@ -7,7 +7,7 @@ from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.post_parameters_header_response_200 import PostParametersHeaderResponse200
 from ...models.public_error import PublicError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
@@ -72,6 +72,9 @@ def sync_detailed(
     string_header: str,
     number_header: float,
     integer_header: int,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostParametersHeaderResponse200 | PublicError]:
     """
     Args:
@@ -94,6 +97,12 @@ def sync_detailed(
         number_header=number_header,
         integer_header=integer_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -109,6 +118,9 @@ def sync(
     string_header: str,
     number_header: float,
     integer_header: int,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostParametersHeaderResponse200 | PublicError | None:
     """
     Args:
@@ -131,6 +143,9 @@ def sync(
         string_header=string_header,
         number_header=number_header,
         integer_header=integer_header,
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 
 
@@ -141,6 +156,9 @@ async def asyncio_detailed(
     string_header: str,
     number_header: float,
     integer_header: int,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[PostParametersHeaderResponse200 | PublicError]:
     """
     Args:
@@ -163,6 +181,12 @@ async def asyncio_detailed(
         number_header=number_header,
         integer_header=integer_header,
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(**kwargs)
 
@@ -176,6 +200,9 @@ async def asyncio(
     string_header: str,
     number_header: float,
     integer_header: int,
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> PostParametersHeaderResponse200 | PublicError | None:
     """
     Args:
@@ -199,5 +226,8 @@ async def asyncio(
             string_header=string_header,
             number_header=number_header,
             integer_header=integer_header,
+            headers=headers,
+            timeout=timeout,
+            auth=auth,
         )
     ).parsed

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -5,7 +5,7 @@ from urllib.parse import quote
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response, UNSET, Unset
 from ... import errors
 
 {% for relative in endpoint.relative_imports | sort %}
@@ -103,12 +103,21 @@ def _build_response(*, client: AuthenticatedClient | Client, response: httpx.Res
 
 def sync_detailed(
     {{ arguments(endpoint) | indent(4) }}
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[{{ return_string }}]:
     {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
 
     kwargs = _get_kwargs(
         {{ kwargs(endpoint, include_client=False) }}
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = client.get_httpx_client().request(
         **kwargs,
@@ -119,22 +128,37 @@ def sync_detailed(
 {% if parsed_responses %}
 def sync(
     {{ arguments(endpoint) | indent(4) }}
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> {{ return_string }} | None:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
 
     return sync_detailed(
         {{ kwargs(endpoint) }}
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     ).parsed
 {% endif %}
 
 async def asyncio_detailed(
     {{ arguments(endpoint) | indent(4) }}
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> Response[{{ return_string }}]:
     {{ docstring(endpoint, return_string, is_detailed=true) | indent(4) }}
 
     kwargs = _get_kwargs(
         {{ kwargs(endpoint, include_client=False) }}
     )
+    if headers is not None:
+        kwargs["headers"] = {**kwargs.get("headers", {}), **headers}
+    if not isinstance(timeout, Unset):
+        kwargs["timeout"] = timeout
+    if not isinstance(auth, Unset):
+        kwargs["auth"] = auth
 
     response = await client.get_async_httpx_client().request(
         **kwargs
@@ -145,10 +169,16 @@ async def asyncio_detailed(
 {% if parsed_responses %}
 async def asyncio(
     {{ arguments(endpoint) | indent(4) }}
+    headers: dict[str, str] | None = None,
+    timeout: httpx.Timeout | None | Unset = UNSET,
+    auth: httpx.Auth | None | Unset = UNSET,
 ) -> {{ return_string }} | None:
     {{ docstring(endpoint, return_string, is_detailed=false) | indent(4) }}
 
     return (await asyncio_detailed(
         {{ kwargs(endpoint) }}
+        headers=headers,
+        timeout=timeout,
+        auth=auth,
     )).parsed
 {% endif %}


### PR DESCRIPTION
Adds optional `headers`, `timeout`, and `auth` keyword arguments to all generated endpoint functions (sync_detailed, asyncio_detailed, sync, asyncio). These are forwarded directly to the underlying httpx `.request()` call, allowing per-request overrides without creating a new client instance or disrupting the shared connection pool.

`with_headers()` and `with_timeout()` mutate the original client's underlying httpx client as a side effect and cause the returned client to open a new connection pool on first use, making them unsafe for runtime per-request use (especially in concurrent async code).