### PR TITLE
fix: Handle octet-stream content media type as binary format

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -74,7 +74,7 @@ def _string_based_property(
             description=data.description,
             example=data.example,
         )
-    if string_format == "binary":
+    if string_format == "binary" or data.content_media_type == "application/octet-stream":
         return FileProperty.build(
             name=name,
             required=required,

--- a/openapi_python_client/schema/openapi_schema_pydantic/schema.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/schema.py
@@ -48,6 +48,7 @@ class Schema(BaseModel):
     additionalProperties: bool | ReferenceOr["Schema"] | None = None
     description: str | None = None
     schema_format: str | None = Field(default=None, alias="format")
+    content_media_type: str | None = Field(default=None, alias="contentMediaType")
     default: Any | None = None
     nullable: bool = Field(default=False)
     discriminator: Discriminator | None = None

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -17,6 +17,7 @@ from openapi_python_client.parser.properties import (
     build_schemas,
     property_from_data,
 )
+from openapi_python_client.parser.properties.string import StringProperty
 from openapi_python_client.schema import Parameter, Reference, Schema
 from openapi_python_client.utils import ClassName, PythonIdentifier
 
@@ -223,6 +224,35 @@ class TestStringBasedProperty:
             name=name, required=required, data=data, schemas=Schemas(), config=config, parent_name=""
         )
         assert p == file_property_factory(name=name, required=required)
+
+    @pytest.mark.parametrize(
+        "content_media_type,schema_format",
+        [
+            pytest.param("application/octet-stream", None, id="content-media-type-only"),
+            pytest.param("application/octet-stream", "binary", id="both-content-media-type-and-binary-format"),
+        ],
+    )
+    def test__string_based_property_content_media_type(
+        self, file_property_factory, config, content_media_type, schema_format
+    ):
+        name = "file_prop"
+        required = True
+        data = oai.Schema(type="string", contentMediaType=content_media_type, format=schema_format)
+
+        p, _ = property_from_data(
+            name=name, required=required, data=data, schemas=Schemas(), config=config, parent_name=""
+        )
+        assert p == file_property_factory(name=name, required=required)
+
+    def test__string_based_property_non_binary_content_media_type_ignored(self, config):
+        name = "text_prop"
+        required = True
+        data = oai.Schema(type="string", contentMediaType="text/plain")
+
+        p, _ = property_from_data(
+            name=name, required=required, data=data, schemas=Schemas(), config=config, parent_name=""
+        )
+        assert isinstance(p, StringProperty)
 
 
 class TestCreateSchemas:


### PR DESCRIPTION
Fastapi [fixed](https://fastapi.tiangolo.com/release-notes/#fixes_1) their spec generator to output `contentMediaType: application/octet-stream` instead of `format: binary`.
This results in a changed behaviour for the generated client when it comes to file uploads going from taking a File object to taking a string. 
This patch should fix that.