### PR TITLE
BUG: If a float-specified field holds an integer number, the resultin…

### DIFF
--- a/openapi_python_client/templates/model.py.jinja
+++ b/openapi_python_client/templates/model.py.jinja
@@ -5,6 +5,7 @@ from typing import Any, TypeVar, BinaryIO, TextIO, TYPE_CHECKING, Generator
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+
 {% if model.is_multipart_body %}
 import json
 from .. import types
@@ -23,6 +24,14 @@ if TYPE_CHECKING:
   {{ lazy_import }}
 {% endfor %}
 
+
+def json_aware_cast(typ, val):
+    # json does not distinguish between float and int, but the scheme carries this information.
+    # So cast it here, to actually get correct types.
+    # https://json-schema.org/understanding-json-schema/reference/numeric
+    if issubclass(float, typ) and not issubclass(int, typ) and isinstance(val, int):
+        val = float(val)
+    return cast(typ, val)
 
 {% if model.additional_properties %}
 {% set additional_property_type = 'Any' if model.additional_properties == True else model.additional_properties.get_type_string() %}

--- a/openapi_python_client/templates/property_templates/union_property.py.jinja
+++ b/openapi_python_client/templates/property_templates/union_property.py.jinja
@@ -33,7 +33,7 @@ def _parse_{{ property.python_name }}(data: object) -> {{ property.get_type_stri
     {% endif %}
     {% endfor %}
     {% if ns.contains_unmodified_properties %}
-    return cast({{ property.get_type_string() }}, data)
+    return json_aware_cast({{ property.get_type_string() }}, data)
     {% endif %}
 
 {{ property.python_name }} = _parse_{{ property.python_name }}({{ source }})


### PR DESCRIPTION
…g object is int instead of float.

If a float field is specified, and the float is e.g. 5.0, representing it as "5" is valid json ([because it does not destinguish between "integer" floats and ints](https://json-schema.org/understanding-json-schema/reference/numeric)). Right now, this results in an `int` object in python, even though this violates the schema. 

This is kind of a quick-and-dirty patch to the issue, but it _does_ solve the problem at hand.

Ideas how to solve the problem in a cleaner way are much appreciated :)