### PR TITLE
Fix: Model generation using `oneOf`, `anyOf` & `type` lists

### DIFF
--- a/openapi_python_client/parser/properties/union.py
+++ b/openapi_python_client/parser/properties/union.py
@@ -5,6 +5,7 @@ from itertools import chain
 from typing import Any, ClassVar, cast
 
 from attr import define, evolve
+from deepmerge import always_merger
 
 from ... import Config
 from ... import schema as oai
@@ -73,6 +74,17 @@ class UnionProperty(PropertyProtocol):
                 subscript = sub_prop_data.title
             else:
                 subscript = f"type_{i}"
+
+            if isinstance(sub_prop_data, oai.Schema):
+                merged_data = oai.Schema.model_validate(always_merger.merge(
+                    data.model_dump(exclude_unset=True),
+                    sub_prop_data.model_dump(exclude_unset=True),
+                ))
+                merged_data.oneOf = sub_prop_data.oneOf
+                merged_data.anyOf = sub_prop_data.anyOf
+                if getattr(sub_prop_data, 'type', None) is not None:
+                    merged_data.type = sub_prop_data.type
+                sub_prop_data = merged_data
 
             sub_prop, schemas = property_from_data(
                 name=f"{name}_{subscript}",
@@ -144,7 +156,7 @@ class UnionProperty(PropertyProtocol):
     @staticmethod
     def _get_type_string_from_inner_type_strings(inner_types: set[str]) -> str:
         if len(inner_types) == 1:
-            return inner_types.pop()
+            return next(iter(inner_types))
         return " | ".join(sorted(inner_types, key=lambda x: x.lower()))
 
     def get_base_type_string(self) -> str:

--- a/openapi_python_client/schema/openapi_schema_pydantic/reference.py
+++ b/openapi_python_client/schema/openapi_schema_pydantic/reference.py
@@ -22,6 +22,7 @@ class Reference(BaseModel):
     model_config = ConfigDict(
         extra="allow",
         populate_by_name=True,
+        serialize_by_alias=True,
         json_schema_extra={
             "examples": [{"$ref": "#/components/schemas/Pet"}, {"$ref": "Pet.json"}, {"$ref": "definitions.json#/Pet"}]
         },

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:0b2b3482575664902f97136f7fff1463564ee31dd68fa88df4c7bcda75aee8a9"
+content_hash = "sha256:bc0b14276777fb21b4396860471149adb061b9b1f74fcc27a742c65d5e169458"
 
 [[metadata.targets]]
 requires_python = "~=3.10"
@@ -332,6 +332,20 @@ files = [
     {file = "coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b"},
     {file = "coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0"},
     {file = "coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91"},
+]
+
+[[package]]
+name = "deepmerge"
+version = "2.0"
+requires_python = ">=3.8"
+summary = "A toolset for deeply merging Python dictionaries."
+groups = ["default"]
+dependencies = [
+    "typing-extensions; python_version <= \"3.9\"",
+]
+files = [
+    {file = "deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00"},
+    {file = "deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx>=0.23.0,<0.29.0",
     "ruamel.yaml>=0.18.6,<0.20.0",
     "ruff>=0.2",
+    "deepmerge>=2.0",
 ]
 name = "openapi-python-client"
 version = "0.28.3"


### PR DESCRIPTION
According to the JSON Schema [spec](https://learnjsonschema.com/2019-09/applicator/oneof), when a type definition has `oneOf`, `anyOf` or `type` variation, the variant definition might contain only specific fields, rather than a complete type or reference:

```yaml
SomeType:
  type: object
  properties:
    x: {type: integer}
    y: {type: integer}
    z: {type: integer}
  required: [x]
  oneOf:
    - required: [y]
    - required: [z]
```

Currently, in such case the entire type fails to generate and gets treated as `Any`, resulting in lacking validation.

This implements the proper merging behavior, allowing to fully generate such types with their variants.

Additionally, replaces a relevant error-prone mutating operation, stumbled upon during debugging of this problem, with a non-mutating one due to unnecessity of the former.