### PR TITLE
Fix: Pass OpenAPI schema data to all property types

### DIFF
--- a/openapi_python_client/parser/properties/__init__.py
+++ b/openapi_python_client/parser/properties/__init__.py
@@ -64,6 +64,7 @@ def _string_based_property(
             python_name=python_name,
             description=data.description,
             example=data.example,
+            data=data,
         )
     if string_format == "date":
         return DateProperty.build(
@@ -73,6 +74,7 @@ def _string_based_property(
             python_name=python_name,
             description=data.description,
             example=data.example,
+            data=data,
         )
     if string_format == "binary":
         return FileProperty.build(
@@ -82,6 +84,7 @@ def _string_based_property(
             python_name=python_name,
             description=data.description,
             example=data.example,
+            data=data,
         )
     if string_format == "uuid":
         return UuidProperty.build(
@@ -91,6 +94,7 @@ def _string_based_property(
             python_name=python_name,
             description=data.description,
             example=data.example,
+            data=data,
         )
     return StringProperty.build(
         name=name,
@@ -99,6 +103,7 @@ def _string_based_property(
         python_name=python_name,
         description=data.description,
         example=data.example,
+        data=data,
     )
 
 
@@ -193,6 +198,7 @@ def property_from_data(  # noqa: PLR0911, PLR0912
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
                 example=data.example,
+                data=data,
             ),
             schemas,
         )
@@ -232,6 +238,7 @@ def property_from_data(  # noqa: PLR0911, PLR0912
                 const=data.const,
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
+                data=data,
             ),
             schemas,
         )
@@ -249,6 +256,7 @@ def property_from_data(  # noqa: PLR0911, PLR0912
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
                 example=data.example,
+                data=data,
             ),
             schemas,
         )
@@ -261,6 +269,7 @@ def property_from_data(  # noqa: PLR0911, PLR0912
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
                 example=data.example,
+                data=data,
             ),
             schemas,
         )
@@ -273,6 +282,7 @@ def property_from_data(  # noqa: PLR0911, PLR0912
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
                 example=data.example,
+                data=data,
             ),
             schemas,
         )

--- a/openapi_python_client/parser/properties/any.py
+++ b/openapi_python_client/parser/properties/any.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from attr import define
 
 from ...utils import PythonIdentifier
+from ... import schema as oai
 from .protocol import PropertyProtocol, Value
 
 

--- a/openapi_python_client/parser/properties/boolean.py
+++ b/openapi_python_client/parser/properties/boolean.py
@@ -20,6 +20,7 @@ class BooleanProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "bool"
     _json_type_string: ClassVar[str] = "bool"
@@ -40,6 +41,7 @@ class BooleanProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> BooleanProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -51,6 +53,7 @@ class BooleanProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/const.py
+++ b/openapi_python_client/parser/properties/const.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, overload
 from attr import define
 
 from ...utils import PythonIdentifier
+from ... import schema as oai
 from ..errors import PropertyError
 from .protocol import PropertyProtocol, Value
 from .string import StringProperty
@@ -21,6 +22,7 @@ class ConstProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: None
+    data: oai.Schema
     template: ClassVar[str] = "const_property.py.jinja"
 
     @classmethod
@@ -33,6 +35,7 @@ class ConstProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         required: bool,
         description: str | None,
+        data: oai.Schema,
     ) -> ConstProperty | PropertyError:
         """
         Create a `ConstProperty` the right way.
@@ -55,6 +58,7 @@ class ConstProperty(PropertyProtocol):
             default=None,
             description=description,
             example=None,
+            data=data,
         )
         converted_default = prop.convert_value(default)
         if isinstance(converted_default, PropertyError):

--- a/openapi_python_client/parser/properties/date.py
+++ b/openapi_python_client/parser/properties/date.py
@@ -6,6 +6,7 @@ from attr import define
 from dateutil.parser import isoparse
 
 from ...utils import PythonIdentifier
+from ... import schema as oai
 from ..errors import PropertyError
 from .protocol import PropertyProtocol, Value
 
@@ -20,6 +21,7 @@ class DateProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "datetime.date"
     _json_type_string: ClassVar[str] = "str"
@@ -34,6 +36,7 @@ class DateProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema
     ) -> DateProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -46,6 +49,7 @@ class DateProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/datetime.py
+++ b/openapi_python_client/parser/properties/datetime.py
@@ -6,6 +6,7 @@ from attr import define
 from dateutil.parser import isoparse
 
 from ...utils import PythonIdentifier
+from ... import schema as oai
 from ..errors import PropertyError
 from .protocol import PropertyProtocol, Value
 
@@ -22,6 +23,7 @@ class DateTimeProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "datetime.datetime"
     _json_type_string: ClassVar[str] = "str"
@@ -36,6 +38,7 @@ class DateTimeProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> DateTimeProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -48,6 +51,7 @@ class DateTimeProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/enum_property.py
+++ b/openapi_python_client/parser/properties/enum_property.py
@@ -29,6 +29,7 @@ class EnumProperty(PropertyProtocol):
     python_name: utils.PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
     values: dict[str, ValueType]
     class_info: Class
     value_type: type[ValueType]
@@ -142,6 +143,7 @@ class EnumProperty(PropertyProtocol):
             python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
             description=data.description,
             example=data.example,
+            data=data,
         )
         checked_default = prop.convert_value(data.default)
         if isinstance(checked_default, PropertyError):

--- a/openapi_python_client/parser/properties/file.py
+++ b/openapi_python_client/parser/properties/file.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar
 from attr import define
 
 from ...utils import PythonIdentifier
+from ... import schema as oai
 from ..errors import PropertyError
 from .protocol import PropertyProtocol
 
@@ -19,6 +20,7 @@ class FileProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "File"
     # Return type of File.to_tuple()
@@ -34,6 +36,7 @@ class FileProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> FileProperty | PropertyError:
         default_or_err = cls.convert_value(default)
         if isinstance(default_or_err, PropertyError):
@@ -46,6 +49,7 @@ class FileProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/float.py
+++ b/openapi_python_client/parser/properties/float.py
@@ -20,6 +20,7 @@ class FloatProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "float"
     _json_type_string: ClassVar[str] = "float"
@@ -40,6 +41,7 @@ class FloatProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> FloatProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -52,6 +54,7 @@ class FloatProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/int.py
+++ b/openapi_python_client/parser/properties/int.py
@@ -20,6 +20,7 @@ class IntProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "int"
     _json_type_string: ClassVar[str] = "int"
@@ -40,6 +41,7 @@ class IntProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> IntProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -52,6 +54,7 @@ class IntProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/list_property.py
+++ b/openapi_python_client/parser/properties/list_property.py
@@ -21,6 +21,7 @@ class ListProperty(PropertyProtocol):
     python_name: utils.PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
     inner_property: PropertyProtocol
     template: ClassVar[str] = "list_property.py.jinja"
 
@@ -98,6 +99,7 @@ class ListProperty(PropertyProtocol):
                 python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
                 description=data.description,
                 example=data.example,
+                data=data,
             ),
             schemas,
         )

--- a/openapi_python_client/parser/properties/literal_enum_property.py
+++ b/openapi_python_client/parser/properties/literal_enum_property.py
@@ -29,6 +29,7 @@ class LiteralEnumProperty(PropertyProtocol):
     python_name: utils.PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
     values: set[ValueType]
     class_info: Class
     value_type: type[ValueType]
@@ -140,6 +141,7 @@ class LiteralEnumProperty(PropertyProtocol):
             python_name=utils.PythonIdentifier(value=name, prefix=config.field_prefix),
             description=data.description,
             example=data.example,
+            data=data,
         )
         checked_default = prop.convert_value(data.default)
         if isinstance(checked_default, PropertyError):

--- a/openapi_python_client/parser/properties/none.py
+++ b/openapi_python_client/parser/properties/none.py
@@ -20,6 +20,7 @@ class NoneProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _allowed_locations: ClassVar[set[oai.ParameterLocation]] = {
         oai.ParameterLocation.QUERY,
@@ -38,6 +39,7 @@ class NoneProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema
     ) -> NoneProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -49,6 +51,7 @@ class NoneProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/string.py
+++ b/openapi_python_client/parser/properties/string.py
@@ -21,6 +21,7 @@ class StringProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
     _type_string: ClassVar[str] = "str"
     _json_type_string: ClassVar[str] = "str"
     _allowed_locations: ClassVar[set[oai.ParameterLocation]] = {
@@ -39,6 +40,7 @@ class StringProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> StringProperty | PropertyError:
         checked_default = cls.convert_value(default)
         return cls(
@@ -48,6 +50,7 @@ class StringProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod

--- a/openapi_python_client/parser/properties/union.py
+++ b/openapi_python_client/parser/properties/union.py
@@ -24,6 +24,7 @@ class UnionProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
     inner_properties: list[PropertyProtocol]
     template: ClassVar[str] = "union_property.py.jinja"
 
@@ -112,6 +113,7 @@ class UnionProperty(PropertyProtocol):
             python_name=PythonIdentifier(value=name, prefix=config.field_prefix),
             description=data.description,
             example=data.example,
+            data=data,
         )
         default_or_error = prop.convert_value(data.default)
         if isinstance(default_or_error, PropertyError):

--- a/openapi_python_client/parser/properties/uuid.py
+++ b/openapi_python_client/parser/properties/uuid.py
@@ -21,6 +21,7 @@ class UuidProperty(PropertyProtocol):
     python_name: PythonIdentifier
     description: str | None
     example: str | None
+    data: oai.Schema
 
     _type_string: ClassVar[str] = "UUID"
     _json_type_string: ClassVar[str] = "str"
@@ -41,6 +42,7 @@ class UuidProperty(PropertyProtocol):
         python_name: PythonIdentifier,
         description: str | None,
         example: str | None,
+        data: oai.Schema,
     ) -> UuidProperty | PropertyError:
         checked_default = cls.convert_value(default)
         if isinstance(checked_default, PropertyError):
@@ -53,6 +55,7 @@ class UuidProperty(PropertyProtocol):
             python_name=python_name,
             description=description,
             example=example,
+            data=data,
         )
 
     @classmethod


### PR DESCRIPTION
Previously, OpenAPI data was only passed to ModelProperty, while other property types did not receive it. This caused missing metadata required for validation.