### PR TITLE
feat: Update `uv_build` to 0.11 when using `--meta=uv`

### DIFF
--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -16,7 +16,7 @@ module-name = "test_3_1_features_client"
 module-root = ""
 
 [build-system]
-requires = ["uv_build>=0.10.0,<0.11.0"]
+requires = ["uv_build>=0.11.0,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.ruff]

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -16,5 +16,5 @@ module-name = "{{ package_name }}"
 module-root = ""
 
 [build-system]
-requires = ["uv_build>=0.10.0,<0.11.0"]
+requires = ["uv_build>=0.11.0,<0.12.0"]
 build-backend = "uv_build"


### PR DESCRIPTION
`uv` 0.11.0 was released a few months ago

- https://github.com/astral-sh/uv/releases/tag/0.11.0