### PR TITLE
feat: Import endpoint modules in __init__

### DIFF
--- a/openapi_python_client/__init__.py
+++ b/openapi_python_client/__init__.py
@@ -276,7 +276,11 @@ class Project:
             endpoint_init_path = tag_dir / "__init__.py"
             endpoint_init_template = self.env.get_template("endpoint_init.py.jinja")
             endpoint_init_path.write_text(
-                endpoint_init_template.render(endpoint_collection=collection),
+                endpoint_init_template.render(
+                    endpoint_collection=collection,
+                    modules=(utils.PythonIdentifier(endpoint.name, self.config.field_prefix) \
+                             for endpoint in collection.endpoints),
+                ),
                 encoding=self.config.file_encoding,
             )
 

--- a/openapi_python_client/templates/endpoint_init.py.jinja
+++ b/openapi_python_client/templates/endpoint_init.py.jinja
@@ -1,1 +1,2 @@
 """ Contains endpoint functions for accessing the API """
+from . import {{ modules | join(", ") }}


### PR DESCRIPTION
Import generated endpoint modules in `__init__.py` using provided modules list.