### PR TITLE
chore: Remove test dependency on Click and improve CI venv handling

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
         run: pip install pdm
 
       - name: Install Dependencies
-        run: pdm install
+        run: pdm sync --clean
 
       - name: Check formatting
         run: pdm run ruff format . --check
@@ -96,7 +96,7 @@ jobs:
         run: pip install pdm
 
       - name: Install minimum dependencies
-        run: pdm install -L pdm.minimal.lock
+        run: pdm sync --clean -L pdm.minimal.lock
 
       - name: Run mypy
         run: pdm mypy --show-error-codes
@@ -178,7 +178,7 @@ jobs:
         run: |
           cd integration-tests
           pip install pdm
-          pdm install -L ${{ matrix.lockfile }}
+          pdm sync --clean -L ${{ matrix.lockfile }}
       - name: Run Tests
         run: |
           cd integration-tests

--- a/end_to_end_tests/functional_tests/helpers.py
+++ b/end_to_end_tests/functional_tests/helpers.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict
 import re
 
-from click.testing import Result
+from typer.testing import Result
 import pytest
 
 from end_to_end_tests.generated_client import generate_client_from_inline_spec, GeneratedClientContext

--- a/end_to_end_tests/generated_client.py
+++ b/end_to_end_tests/generated_client.py
@@ -9,8 +9,7 @@ from typing import Any
 
 from attrs import define
 import pytest
-from click.testing import Result
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from openapi_python_client.cli import app
 

--- a/end_to_end_tests/test_end_to_end.py
+++ b/end_to_end_tests/test_end_to_end.py
@@ -5,8 +5,7 @@ from filecmp import cmpfiles, dircmp
 from pathlib import Path
 
 import pytest
-from click.testing import Result
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from end_to_end_tests.generated_client import (
     _run_command, generate_client, generate_client_from_inline_spec,


### PR DESCRIPTION
Fixes #1441 and hopefully prevents similar issues by doing `pdm sync --clean` intead of `pdm install` in CI