### PR TITLE
fix: fall back to schema key when two schemas share a title

### DIFF
--- a/.changeset/fall_back_to_schema_key_when_titles_collide.md
+++ b/.changeset/fall_back_to_schema_key_when_titles_collide.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Fall back to schema key when two schemas share a `title`
+
+Tools like FastAPI emit duplicate `title` values for input and output variants of the same model (for example `Thing-Input` and `Thing-Output` both carrying `title: Thing`). The first variant took the title-derived class name and the second was silently dropped with an `Attempted to generate duplicate models` error, along with every endpoint that referenced it.
+
+The second variant now falls back to a class name derived from its schema key (`Thing-Output` becomes `ThingOutput`), so both schemas survive and their endpoints generate.

--- a/end_to_end_tests/functional_tests/generated_code_execution/test_title_collisions.py
+++ b/end_to_end_tests/functional_tests/generated_code_execution/test_title_collisions.py
@@ -1,0 +1,40 @@
+from end_to_end_tests.functional_tests.helpers import (
+    with_generated_client_fixture,
+    with_generated_code_imports,
+)
+
+
+@with_generated_client_fixture(
+"""
+components:
+  schemas:
+    Thing-Input:
+      title: Thing
+      type: object
+      properties:
+        name: {"type": "string"}
+    Thing-Output:
+      title: Thing
+      type: object
+      properties:
+        name: {"type": "string"}
+        id: {"type": "string"}
+"""
+)
+@with_generated_code_imports(".models.Thing", ".models.ThingOutput")
+class TestCollidingTitlesFallBackToSchemaKey:
+    """FastAPI emits the same ``title`` for input and output variants of a model
+    (for example ``Thing-Input`` and ``Thing-Output`` both carrying ``title: Thing``).
+    The first variant takes the title-derived class name, and the second falls back
+    to its schema key so both schemas survive.
+    """
+
+    def test_first_variant_uses_title(self, Thing):
+        assert Thing.__name__ == "Thing"
+        instance = Thing(name="x")
+        assert instance.to_dict() == {"name": "x"}
+
+    def test_second_variant_uses_schema_key(self, ThingOutput):
+        assert ThingOutput.__name__ == "ThingOutput"
+        instance = ThingOutput(name="x", id="123")
+        assert instance.to_dict() == {"name": "x", "id": "123"}

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -74,6 +74,10 @@ class ModelProperty(PropertyProtocol):
             else:
                 class_string = title
         class_info = Class.from_string(string=class_string, config=config)
+        if class_info.name in schemas.classes_by_name and data.title and name:
+            fallback_class_info = Class.from_string(string=name, config=config)
+            if fallback_class_info.name not in schemas.classes_by_name:
+                class_info = fallback_class_info
         model_roots = {*roots, class_info.name}
         required_properties: list[Property] | None = None
         optional_properties: list[Property] | None = None

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -164,6 +164,23 @@ class TestBuild:
         assert new_schemas == schemas
         assert err == PropertyError(detail='Attempted to generate duplicate models with name "OtherModel"', data=data)
 
+    def test_model_name_conflict_fallback(self, config):
+        data = oai.Schema.model_construct(title="OtherModel")
+        schemas = Schemas(classes_by_name={"OtherModel": None})
+
+        model, _new_schemas = ModelProperty.build(
+            data=data,
+            name="UniqueModelName",
+            schemas=schemas,
+            required=True,
+            parent_name=None,
+            config=config,
+            roots={"root"},
+            process_properties=True,
+        )
+
+        assert model.class_info.name == "UniqueModelName"
+
     @pytest.mark.parametrize(
         "name, title, parent_name, use_title_prefixing, expected",
         ids=(


### PR DESCRIPTION
# fix: fall back to schema key when two schemas share a title

## Summary

When two component schemas declare the same `title`, the second one was
silently dropped along with every endpoint that referenced it. This PR
makes the second variant fall back to a class name derived from its
schema key so both schemas survive.

## Problem

Tools like FastAPI emit duplicate `title` values for input and output
variants of the same model (for example `Thing-Input` and `Thing-Output`
both carrying `title: Thing`). The class name is derived from the title,
so the second variant collides with the first and is rejected with
`Attempted to generate duplicate models`. The generator emits a warning
but exits 0, so the schema and every endpoint that referenced it are
silently dropped from the generated client.

### Minimal reproduction

```yaml
components:
  schemas:
    Thing-Input:
      title: Thing
      type: object
      properties:
        name: { "type": "string" }
    Thing-Output:
      title: Thing
      type: object
      properties:
        name: { "type": "string" }
        id:   { "type": "string" }
```

Before this PR: `Thing-Output` and any endpoint that references it are
absent from the generated client, and the only signal is a warning on
stderr.

## Fix

In `ModelProperty.build`, when the title-derived class name is already
taken, fall back to a class name derived from the schema key
(`Thing-Output` becomes `ThingOutput`) provided that key is unique.
The original schema's name is preserved, and both variants and their
endpoints generate.

The fallback is guarded by `data.title and name` so it only triggers
in the duplicate-title case. If the fallback name also collides, the
existing `Attempted to generate duplicate models` error path still
fires unchanged.

## Tests

- Functional test:
  `end_to_end_tests/functional_tests/generated_code_execution/test_title_collisions.py`
  — uses the inline spec above and asserts both `Thing` and
  `ThingOutput` exist and round-trip correctly.
- Unit test in
  `tests/test_parser/test_properties/test_model_property.py`
  (`TestBuild::test_model_name_conflict_fallback`) exercises the new
  branch in `ModelProperty.build` directly.

## Local verification

```
pdm install
pdm run ruff format . --check
pdm run ruff check .
pdm mypy --show-error-codes
pdm test_with_coverage
```

All green on Python 3.14. 100% coverage on the changed file
(`model_property.py`). Golden-record snapshot tests pass without
regeneration — no generated output changes for any existing spec in
the upstream baseline.

## Risk

- **Ordering**: the first variant encountered wins the title-derived
  name; the second falls back to the schema-key-derived name. For the
  motivating `Thing-Input` / `Thing-Output` case this is the desired
  result. A schema author who expected the *second* variant to claim
  the title would see different output, but that case previously
  errored out, so this is a strict improvement over the prior failure
  mode.
- **No public-API change.** The fix is a single conditional in
  `ModelProperty.build`; nothing else in the parser or templates is
  touched.

## Related

Companion PR: #1449 — a second independent fix for
freeform-object defaults, surfaced from the same downstream spec.
The two PRs share no code paths and can land in either order.
