### PR TITLE
fix: ignore an empty object default instead of dropping the schema

### DIFF
--- a/.changeset/support_empty_dict_default_on_freeform_objects.md
+++ b/.changeset/support_empty_dict_default_on_freeform_objects.md
@@ -1,0 +1,9 @@
+---
+default: patch
+---
+
+# Support `default: {}` on freeform object schemas
+
+A schema declared as `type: object` with `additionalProperties: true` and no declared properties (often appearing inside an `anyOf` with `null`) could not carry a `default: {}`. The parser rejected the default with `ModelProperty cannot have a default value`, which silently dropped the enclosing schema and every endpoint that referenced it.
+
+The default `{}` is now accepted on such freeform models and generates an empty-container initializer. The imports of inner models with a non-`None` default are also promoted from lazy `TYPE_CHECKING` imports to runtime imports, so the generated default expression resolves correctly at class-definition time.

--- a/end_to_end_tests/functional_tests/generated_code_execution/test_freeform_object_defaults.py
+++ b/end_to_end_tests/functional_tests/generated_code_execution/test_freeform_object_defaults.py
@@ -1,0 +1,37 @@
+from end_to_end_tests.functional_tests.helpers import (
+    with_generated_client_fixture,
+    with_generated_code_imports,
+)
+
+
+@with_generated_client_fixture(
+"""
+components:
+  schemas:
+    ModelWithFreeformDefault:
+      type: object
+      properties:
+        extras:
+          anyOf:
+            - type: object
+              additionalProperties: true
+            - type: "null"
+          default: {}
+"""
+)
+@with_generated_code_imports(".models.ModelWithFreeformDefault")
+class TestFreeformObjectDefault:
+    """A freeform object (``type: object`` with ``additionalProperties: true`` and no
+    declared properties) inside a union with ``default: {}`` should generate a model
+    whose default initializer constructs the empty inner container.
+    """
+
+    def test_default_is_constructed(self, ModelWithFreeformDefault):
+        instance = ModelWithFreeformDefault()
+        assert instance.extras.additional_properties == {}
+
+    def test_explicit_value_overrides_default(self, ModelWithFreeformDefault):
+        inner_type = type(ModelWithFreeformDefault().extras)
+        custom = inner_type.from_dict({"a": 1})
+        instance = ModelWithFreeformDefault(extras=custom)
+        assert instance.to_dict() == {"extras": {"a": 1}}

--- a/openapi_python_client/parser/properties/model_property.py
+++ b/openapi_python_client/parser/properties/model_property.py
@@ -125,10 +125,18 @@ class ModelProperty(PropertyProtocol):
         )
         return prop, schemas
 
-    @classmethod
-    def convert_value(cls, value: Any) -> Value | None | PropertyError:
+    def convert_value(self, value: Any) -> Value | None | PropertyError:
         if value is not None:
-            return PropertyError(detail="ModelProperty cannot have a default value")  # pragma: no cover
+            is_empty_dict = isinstance(value, dict) and not value
+            if self.required_properties is not None or self.optional_properties is not None:
+                has_no_props = not self.required_properties and not self.optional_properties
+            else:
+                has_no_props = (
+                    not self.data.properties and not self.data.allOf and not self.data.anyOf and not self.data.oneOf
+                )
+            if is_empty_dict and has_no_props:
+                return Value(python_code=f"{self.class_info.name}()", raw_value=value)
+            return PropertyError(detail="ModelProperty cannot have a default value")
         return None
 
     def __attrs_post_init__(self) -> None:
@@ -157,6 +165,8 @@ class ModelProperty(PropertyProtocol):
                 "from typing import cast",
             }
         )
+        if self.default is not None:
+            imports.add(f"from {prefix}{self.self_import}")
         return imports
 
     def get_lazy_imports(self, *, prefix: str) -> set[str]:
@@ -166,6 +176,8 @@ class ModelProperty(PropertyProtocol):
             prefix: A prefix to put before any relative (local) module names. This should be the number of . to get
             back to the root of the generated client.
         """
+        if self.default is not None:
+            return set()
         return {f"from {prefix}{self.self_import}"}
 
     def set_relative_imports(self, relative_imports: set[str]) -> None:

--- a/openapi_python_client/parser/properties/union.py
+++ b/openapi_python_client/parser/properties/union.py
@@ -196,11 +196,17 @@ class UnionProperty(PropertyProtocol):
         """
         imports = super().get_imports(prefix=prefix)
         for inner_prop in self.inner_properties:
-            imports.update(inner_prop.get_imports(prefix=prefix))
+            if self.default is not None:
+                imports.update(inner_prop.get_imports(prefix=prefix))
+                imports.update(inner_prop.get_lazy_imports(prefix=prefix))
+            else:
+                imports.update(inner_prop.get_imports(prefix=prefix))
         imports.add("from typing import cast")
         return imports
 
     def get_lazy_imports(self, *, prefix: str) -> set[str]:
+        if self.default is not None:
+            return set()
         lazy_imports = super().get_lazy_imports(prefix=prefix)
         for inner_prop in self.inner_properties:
             lazy_imports.update(inner_prop.get_lazy_imports(prefix=prefix))

--- a/tests/test_parser/test_properties/test_model_property.py
+++ b/tests/test_parser/test_properties/test_model_property.py
@@ -40,6 +40,15 @@ class TestModelProperty:
             "from typing import cast",
         }
 
+    def test_get_imports_with_default(self, model_property_factory):
+        prop = model_property_factory(required=False, default="default")
+
+        assert prop.get_imports(prefix="..") == {
+            "from ..types import UNSET, Unset",
+            "from typing import cast",
+            "from ..models.my_module import MyClass",
+        }
+
     def test_get_lazy_imports(self, model_property_factory):
         prop = model_property_factory(required=False)
 
@@ -47,9 +56,51 @@ class TestModelProperty:
             "from ..models.my_module import MyClass",
         }
 
+    def test_get_lazy_imports_with_default(self, model_property_factory):
+        prop = model_property_factory(required=False, default="default")
+
+        assert prop.get_lazy_imports(prefix="..") == set()
+
     def test_get_base_type_string(self, model_property_factory):
         m = model_property_factory()
         assert m.get_base_type_string() == "MyClass"
+
+    def test_convert_value(self, model_property_factory):
+        prop = model_property_factory(
+            required_properties=["prop1"],
+        )
+        assert isinstance(prop.convert_value({}), PropertyError)
+        assert prop.convert_value(None) is None
+
+        empty_prop = model_property_factory(
+            required_properties=[],
+            optional_properties=[],
+        )
+        assert empty_prop.convert_value(None) is None
+        val = empty_prop.convert_value({})
+        assert val.python_code == "MyClass()"
+        assert val.raw_value == {}
+
+    def test_convert_value_unprocessed(self, model_property_factory):
+        # When required_properties is None, it should check self.data (unprocessed)
+        # 1. Schema with properties
+        prop_with_data = model_property_factory(
+            required_properties=None,
+            optional_properties=None,
+            data=oai.Schema.model_construct(properties={"prop1": oai.Schema.model_construct()}),
+        )
+        assert isinstance(prop_with_data.convert_value({}), PropertyError)
+
+        # 2. Empty Schema (freeform)
+        empty_prop_with_data = model_property_factory(
+            required_properties=None,
+            optional_properties=None,
+            data=oai.Schema.model_construct(),
+        )
+        assert empty_prop_with_data.convert_value(None) is None
+        val = empty_prop_with_data.convert_value({})
+        assert val.python_code == "MyClass()"
+        assert val.raw_value == {}
 
 
 class TestBuild:


### PR DESCRIPTION
# fix: support default `{}` on freeform object schemas

## Summary

A freeform object schema (`type: object`, `additionalProperties: true`,
no declared properties) inside an `anyOf` could not carry a
`default: {}`. The parser rejected the default, which silently dropped
the enclosing schema and every endpoint that referenced it. This PR
accepts the empty-dict default and generates a working empty-container
initializer.

## Problem

A schema declared as `type: object` with `additionalProperties: true`
and no declared properties (often appearing inside an `anyOf` with
`null`) could not carry a `default: {}`. `ModelProperty.convert_value`
rejected the default with `ModelProperty cannot have a default value`,
which propagated up as a warning and silently dropped the enclosing
schema and every endpoint that referenced it.

### Minimal reproduction

```yaml
components:
  schemas:
    ModelWithFreeformDefault:
      type: object
      properties:
        extras:
          anyOf:
            - type: object
              additionalProperties: true
            - type: "null"
          default: {}
```

Before this PR: `ModelWithFreeformDefault` is missing from the
generated client; the only signal is a warning on stderr.

## Fix

Three coordinated changes in `model_property.py` and `union.py`:

1. **`ModelProperty.convert_value` accepts `{}`** on a freeform model
   and emits a `ClassName()` constructor call. When
   `required_properties` has not yet been populated, the check falls
   back to the raw schema (`data.properties`, `data.allOf`,
   `data.anyOf`, `data.oneOf`) so a referenced schema still gets the
   correct decision before its properties have been processed.

2. **Import promotion in `ModelProperty`.** A default value forces the
   generated client to import the inner model at runtime rather than
   only under `TYPE_CHECKING`, otherwise the default initializer would
   `NameError` at class-definition time. `get_imports` and
   `get_lazy_imports` are updated so inner-property imports are
   promoted when the property has a non-`None` default.

3. **Import promotion in `UnionProperty`.** The same promotion applies
   to unions that carry a default — every inner property's lazy
   imports become runtime imports so the union's default expression
   resolves at class-definition time.

## Tests

- Functional test:
  `end_to_end_tests/functional_tests/generated_code_execution/test_freeform_object_defaults.py`
  — uses the inline spec above, asserts the model is instantiable
  and that the default `extras` is the empty container.
- Unit tests in
  `tests/test_parser/test_properties/test_model_property.py`:
  - `test_get_imports_with_default` and `test_get_lazy_imports_with_default`
    cover the import-promotion branches.
  - `test_convert_value` and `test_convert_value_unprocessed` cover
    `convert_value`'s new accept/reject decisions, including the
    pre-processing fallback path.

## Local verification

```
pdm install
pdm run ruff format . --check
pdm run ruff check .
pdm mypy --show-error-codes
pdm test_with_coverage
```

All green on Python 3.14. 100% coverage on both changed files
(`model_property.py`, `union.py`) when measured across the full
upstream suite. Golden-record snapshot tests pass without
regeneration — the import-promotion paths are only reachable when a
model has a non-`None` default, which previously errored, so no
existing snapshot can depend on the old behaviour.

## Risk

- **`ModelProperty.convert_value` changes from a `@classmethod` to an
  instance method.** A grep across `openapi_python_client/`, `tests/`,
  and `end_to_end_tests/` finds zero `ModelProperty.convert_value(...)`
  class-level call sites; every caller uses `prop.convert_value(...)`
  via the `PropertyProtocol`. The signature change is invisible to
  existing call sites.
- **Acceptance is conservative**: only `{}` is accepted, and only on
  a model that is genuinely freeform (no `properties`, `allOf`,
  `anyOf`, or `oneOf`). Any other default value still returns
  `PropertyError` with the original message, so models with required
  fields can't slip through with an empty default.
- **Snapshot impact**: confirmed none. Snapshot tests pass without
  `pdm regen`.

## Related

Companion PR: #1448 — a second independent fix for the
title-collision case surfaced from the same downstream spec. The two
PRs share no code paths and can land in either order.
