### PR TITLE
fix: Apply PEP 639 for improved license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 authors = [
     { name = "Dylan Anthony", email = "contact@dylananthony.com" },
 ]
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.11,<4.0"
 dependencies = [
     "jinja2>=3.0.0,<4.0.0",
@@ -25,7 +25,6 @@ keywords = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This follows [PEP 639](https://peps.python.org/pep-0639/) to improve the license metadata:

- Use a text SPDX licence identifier instead of a table, which is deprecated
- Remove licence classifier, which is deprecated