### PR TITLE
fix: allow anonymous security alternatives

### DIFF
--- a/openapi_python_client/parser/openapi.py
+++ b/openapi_python_client/parser/openapi.py
@@ -30,6 +30,13 @@ from .responses import HTTPStatusPattern, Responses, response_from_data
 _PATH_PARAM_REGEX = re.compile("{([a-zA-Z_-][a-zA-Z0-9_-]*)}")
 
 
+def requires_authenticated_client(security: list[dict[str, list[str]]] | None) -> bool:
+    """Return false when an operation permits anonymous access."""
+    if not security:
+        return False
+    return not any(not requirement for requirement in security)
+
+
 def import_string_from_class(class_: Class, prefix: str = "") -> str:
     """Create a string which is used to import a reference"""
     return f"from {prefix}.{class_.module_name} import {class_.name}"
@@ -420,7 +427,7 @@ class Endpoint:
             summary=utils.remove_string_escapes(data.summary) if data.summary else "",
             description=utils.remove_string_escapes(data.description) if data.description else "",
             name=name,
-            requires_security=bool(data.security),
+            requires_security=requires_authenticated_client(data.security),
             tags=tags,
         )
 

--- a/tests/test_parser/test_openapi.py
+++ b/tests/test_parser/test_openapi.py
@@ -555,6 +555,49 @@ class TestEndpoint:
             config=config,
         )
 
+    @pytest.mark.parametrize(
+        ("security", "expected_requires_security"),
+        [
+            ([{}], False),
+            ([{"apiKey": []}, {}], False),
+            ([{"apiKey": []}], True),
+        ],
+    )
+    def test_from_data_security_allows_anonymous_alternative(
+        self,
+        security,
+        expected_requires_security,
+        mocker,
+        config,
+    ):
+        data = oai.Operation.model_construct(
+            description=mocker.MagicMock(),
+            operationId=mocker.MagicMock(),
+            security=security,
+            responses=mocker.MagicMock(),
+        )
+        add_parameters = mocker.patch.object(
+            Endpoint, "add_parameters", return_value=(mocker.MagicMock(), mocker.MagicMock(), mocker.MagicMock())
+        )
+        mocker.patch.object(Endpoint, "_add_responses", return_value=(mocker.MagicMock(), mocker.MagicMock()))
+        path = mocker.MagicMock()
+        method = mocker.MagicMock()
+        mocker.patch("openapi_python_client.utils.remove_string_escapes", return_value=data.description)
+
+        Endpoint.from_data(
+            data=data,
+            path=path,
+            method=method,
+            tags=["default"],
+            schemas=mocker.MagicMock(),
+            responses={},
+            parameters=mocker.MagicMock(),
+            config=config,
+            request_bodies={},
+        )
+
+        assert add_parameters.call_args.kwargs["endpoint"].requires_security is expected_requires_security
+
     def test_from_data_some_bad_bodies(self, config):
         endpoint, _, _ = Endpoint.from_data(
             data=oai.Operation(


### PR DESCRIPTION
## Summary
- Treat an empty OpenAPI security requirement object as an anonymous alternative.
- Keep endpoints that allow API key auth or anonymous access callable with Client as well as AuthenticatedClient.
- Add parser coverage for anonymous-only, API-key-or-anonymous, and API-key-only operations.

## Validation
- uv run --python 3.13 --with mypy --with pytest --with pytest-mock --with pydantic --with attrs --with httpx --with jinja2 --with typer --with ruamel.yaml --with python-multipart --with syrupy python -m pytest tests/test_parser/test_openapi.py -q
- uv run --python 3.13 ruff check openapi_python_client/parser/openapi.py tests/test_parser/test_openapi.py
- uv run --python 3.13 ruff format --check openapi_python_client/parser/openapi.py tests/test_parser/test_openapi.py
