### PR TITLE
feat: Update `uv_build` to 0.12 when using `--meta=uv`

### DIFF
--- a/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
+++ b/end_to_end_tests/metadata_snapshots/uv.pyproject.toml
@@ -15,7 +15,7 @@ module-name = "test_3_1_features_client"
 module-root = ""
 
 [build-system]
-requires = ["uv_build>=0.11.0,<0.12.0"]
+requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"
 
 [tool.ruff]

--- a/openapi_python_client/templates/pyproject_uv.toml.jinja
+++ b/openapi_python_client/templates/pyproject_uv.toml.jinja
@@ -15,5 +15,5 @@ module-name = "{{ package_name }}"
 module-root = ""
 
 [build-system]
-requires = ["uv_build>=0.11.0,<0.12.0"]
+requires = ["uv_build>=0.12.0,<0.13.0"]
 build-backend = "uv_build"


### PR DESCRIPTION
`uv` 0.12.0 is now the latest stable release on PyPI.

- https://github.com/astral-sh/uv/releases/tag/0.12.0

Continues the existing pattern of tracking each new uv minor (#1352, #1396, #1434).

Closes #1472