### PR TITLE
fix: treat array without items as list of Any per OpenAPI 3.1 (#1435)

### DIFF
--- a/.changeset/array_without_items_is_list_of_any.md
+++ b/.changeset/array_without_items_is_list_of_any.md
@@ -1,0 +1,11 @@
+---
+default: patch
+---
+
+# Treat `type: array` without `items` as a list of Any
+
+An array schema with neither `items` nor `prefixItems` is valid in JSON Schema
+2020-12 (OpenAPI 3.1) and means "array of any type". Previously the generator
+failed such schemas with a `PropertyError` ("type array must have items or
+prefixItems defined"), silently skipping the property or `anyOf` branch. It now
+generates a `list[Any]`, equivalent to `items: {}`.

--- a/openapi_python_client/parser/properties/list_property.py
+++ b/openapi_python_client/parser/properties/list_property.py
@@ -58,20 +58,17 @@ class ListProperty(PropertyProtocol):
         """
         from . import property_from_data  # noqa: PLC0415
 
-        if data.items is None and not data.prefixItems:
-            return (
-                PropertyError(
-                    data=data,
-                    detail="type array must have items or prefixItems defined",
-                ),
-                schemas,
-            )
-
         items = data.prefixItems or []
         if data.items:
             items.append(data.items)
 
-        if len(items) == 1:
+        if not items:
+            # An array with neither `items` nor `prefixItems` is valid in JSON
+            # Schema 2020-12 (OpenAPI 3.1) and means "array of any type". Treat
+            # it as equivalent to `items: {}` and generate a list of Any rather
+            # than failing. See issue #1435.
+            inner_schema: oai.Schema | oai.Reference = oai.Schema()
+        elif len(items) == 1:
             inner_schema = items[0]
         else:
             inner_schema = oai.Schema(anyOf=items)

--- a/tests/test_parser/test_properties/test_init.py
+++ b/tests/test_parser/test_properties/test_init.py
@@ -3,7 +3,9 @@ import pytest
 import openapi_python_client.schema as oai
 from openapi_python_client.parser.errors import PropertyError
 from openapi_python_client.parser.properties import (
+    AnyProperty,
     Class,
+    ListProperty,
     ReferencePath,
     Schemas,
     _propogate_removal,
@@ -323,3 +325,23 @@ class TestPropogateRemoval:
         assert schemas.classes_by_name == {class_name: None}
         assert schemas.classes_by_reference == {ref_path: None}
         assert not error.detail
+
+
+class TestArrayWithoutItems:
+    def test_array_without_items_becomes_list_of_any(self, config):
+        """Issue #1435: `{"type": "array"}` with no `items`/`prefixItems` is
+        valid in OpenAPI 3.1 (JSON Schema 2020-12) and means "array of any". It
+        must generate a list of Any instead of failing with a PropertyError."""
+        data = oai.Schema(type="array", description="anything")
+        prop, _ = property_from_data(
+            name=UntrustedString("metrics"),
+            required=True,
+            data=data,
+            schemas=Schemas(),
+            parent_name="parent",
+            config=config,
+        )
+
+        assert isinstance(prop, ListProperty)
+        assert isinstance(prop.inner_property, AnyProperty)
+        assert prop.get_base_type_string().as_unembedded_code() == "list[Any]"


### PR DESCRIPTION
## Problem

When a schema has `"type": "array"` with no `items` (and no `prefixItems`), the generator fails to produce a property, silently skipping the schema or the `anyOf` branch. In JSON Schema 2020-12 (used by OpenAPI 3.1), omitting `items` is valid and means "array of any type", so this should generate a `list[Any]` rather than failing.

Reported cases include a bare `{"type": "array"}` and an `anyOf` branch `{"type": "array", "maxItems": 0}`.

Fixes #1435

## Fix

In `ListProperty.build`, when neither `items` nor `prefixItems` is present, use an empty schema (`oai.Schema()`) as the inner schema, which resolves to an `AnyProperty`. The property is generated as `list[Any]`, equivalent to `items: {}`. Arrays that do declare `items`/`prefixItems` are unaffected.

## Tests

Added `TestArrayWithoutItems::test_array_without_items_becomes_list_of_any`: a `{"type": "array"}` schema with no items now builds a `ListProperty` whose inner property is an `AnyProperty` and whose base type is `list[Any]`. Verified the test FAILS without the fix (returns a `PropertyError`) and PASSES with it. Full `tests/` suite passes (322 passed, 4 skipped); `ruff` and `mypy` clean. Added a changeset per CONTRIBUTING.